### PR TITLE
JSON error envelope + ApiError frontend (closes #82)

### DIFF
--- a/docs/claude/react.md
+++ b/docs/claude/react.md
@@ -44,37 +44,30 @@ Four buckets, pick the right one:
 
 No global store (no Redux, Zustand, Jotai).
 
-## Backend calls — `fetch` + TanStack Query
+## Backend calls — `requestJson` + TanStack Query
 
 One file per backend domain in `src/api/`. Each file exports:
 - TypeScript request/response types matching the backend DTOs (kept aligned by review).
 - TanStack Query hooks: noun-first for queries (`useFoo` / `useFoos` / `useFooById`), verb-first for mutations (`useCreateFoo` / `useUpdateFoo` / `useSendPing`).
 
-**The `fetch` function is module-private — never exported.** Only the hooks are the public surface. A consumer that imports the raw fetch fn skips TanStack Query's cache, deduplication, retry policy, and (when #82 lands) the ApiError envelope parsing. Keeping the fetch fn unexported makes that bypass structurally impossible.
+**The `requestJson` call is module-private — never exported.** Only the hooks are the public surface. A consumer that imports the raw fetch fn skips TanStack Query's cache, deduplication, retry policy, and the `ApiError` envelope parsing. Keeping it unexported makes that bypass structurally impossible.
 
-Components never call `fetch` directly — always go through `src/api/<domain>.ts`. Mutations invalidate relevant queries by query key on success.
+All backend calls go through the shared `requestJson<T>` helper in `src/api/http.ts`. It handles `Content-Type`, `credentials: 'include'`, JSON parsing, and converts the backend's `{ code, message, details? }` error envelope into a typed `ApiError` (also exported from `src/api/http.ts`). Components never call `fetch` directly — always go through `src/api/<domain>.ts`. Mutations invalidate relevant queries by query key on success.
 
 ```ts
 // src/api/contacts.ts
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 
+import { requestJson } from '@/api/http'
+
 export type Contact = { id: string; displayName: string; email: string | null; role: string }
 export type CreateContactRequest = { displayName: string; email?: string }
 
 async function fetchContacts(): Promise<Contact[]> {
-  const r = await fetch('/api/contacts', { credentials: 'include' })
-  if (!r.ok) throw new Error(`Failed to list contacts: ${r.status}`)
-  return r.json()
+  return requestJson<Contact[]>('/api/contacts')
 }
 async function createContact(req: CreateContactRequest): Promise<Contact> {
-  const r = await fetch('/api/contacts', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
-    body: JSON.stringify(req),
-  })
-  if (!r.ok) throw new Error(`Failed to create contact: ${r.status}`)
-  return r.json()
+  return requestJson<Contact>('/api/contacts', { method: 'POST', body: JSON.stringify(req) })
 }
 
 export const contactKeys = { all: ['contacts'] as const, list: () => [...contactKeys.all, 'list'] as const }
@@ -90,9 +83,11 @@ export function useCreateContact() {
 }
 ```
 
-`credentials: 'include'` is non-negotiable — the session cookie rides on every call. Cross-origin in prod relies on a shared parent domain (see `architecture.md` § CORS). In dev, the Vite proxy makes `/api/*` same-origin so the flag is a no-op but stays for prod consistency.
+`requestJson` sets `credentials: 'include'` so the session cookie rides on every call. Cross-origin in prod relies on a shared parent domain (see `architecture.md` § CORS). In dev, the Vite proxy makes `/api/*` same-origin so the flag is a no-op but stays for prod consistency.
 
-**Error mapping**: read the JSON error shape (`{ code, message }`) from the response and surface it. Don't parse error `message` for branching — switch on `code`.
+**Error handling**: failed responses throw a typed `ApiError` carrying `code`, `message`, `status`, and optional `details`. UI code switches on `error.code` for branching (`if (err instanceof ApiError && err.code === 'CONFLICT') ...`) and renders `error.message` for display. Never parse the `message` text for branching — that's what `code` is for. Non-envelope failures (proxy errors, network) surface as `ApiError` with `code: 'HTTP_ERROR'`.
+
+**Inline error display**: use `<ApiErrorAlert error={query.error} />` (from `@/components/ApiErrorAlert`) to render a query/mutation failure inline. It surfaces `ApiError.code` when present and falls back to `.message` otherwise. Override the default title via the `title` prop (`<ApiErrorAlert error={...} title="Couldn't save contact" />`). For code-specific recovery hints, branch on `error.code` *outside* the alert and render siblings — don't bolt a slot onto this component.
 
 ## Components
 
@@ -107,7 +102,7 @@ Default mindset: **small contracts, composition over configuration.** Reusabilit
 | Tier | Where | Reuse | Example |
 |---|---|---|---|
 | Primitives | `src/components/primitives/` | Wide | `AppButton`, `Money` (Mantine wrappers w/ project defaults) |
-| Composite | `src/components/<kind>/` | 2–N places | `StatCard`, `EmptyState`, `ConfirmDialog` |
+| Composite | `src/components/<kind>/` | 2–N places | `ApiErrorAlert`, `StatCard`, `EmptyState`, `ConfirmDialog` |
 | Domain | `src/components/<domain>/` or co-located | 1–2 places | `TransactionRow`, `EmailTriagePanel` |
 
 A `TransactionRow` reused in two places is still domain, not a primitive. Don't over-promote.

--- a/docs/claude/spring-boot.md
+++ b/docs/claude/spring-boot.md
@@ -14,7 +14,19 @@ Controller → Service → DAO → Repository → Database. Strategic detail in 
 - Request/response DTOs are Kotlin `data class`es co-located with the controller. Jackson handles (de)serialization automatically.
 - `@Valid` on the request DTO + Jakarta Bean Validation annotations (`@NotBlank`, `@Size`, `@Email`, etc.) on its fields. Shape validation only — no DB queries.
 - Convert request DTO → service DTO via the api-mapper extension, call service, convert response.
-- Service exceptions propagate; a `@RestControllerAdvice` maps domain exceptions → HTTP status codes (`NotFoundException` → 404, `ValidationException` → 400, `PermissionDeniedException` → 403, `UnauthenticatedException` → 401). Don't catch in the controller.
+- Service exceptions propagate; `com.tcoverwatch.common.api.ApiErrorAdvice` maps each `DomainException` subclass (in `com.tcoverwatch.common.exception`) to a status code. Don't catch in the controller.
+
+| Exception | Status | `code` |
+|---|---|---|
+| `NotFoundException` | 404 | `NOT_FOUND` |
+| `ValidationException` | 400 | `VALIDATION_FAILED` |
+| `PermissionDeniedException` | 403 | `PERMISSION_DENIED` |
+| `UnauthenticatedException` | 401 | `UNAUTHENTICATED` |
+| `ConflictException` | 409 | `CONFLICT` |
+| `FailedPreconditionException` | 422 | `FAILED_PRECONDITION` |
+
+`@Valid` failures (Jakarta `MethodArgumentNotValidException`) route to the same 400 / `VALIDATION_FAILED` envelope with per-field `details.fieldErrors`. Unhandled exceptions → 500 / `INTERNAL_ERROR` with a generic message (no internal leakage); the advice logs them with stack traces.
+
 - Error response body: `{ code: string, message: string, details?: object }`. Frontend reads `code` for branching, `message` for display.
 
 ## Service

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
-import { Container, Stack, Group, Title, Text, Button, Card, Badge, Code, Alert } from '@mantine/core'
+import { Container, Stack, Group, Title, Text, Button, Card, Badge, Code } from '@mantine/core'
 
 import { useSendPing } from '@/api/ping'
+import ApiErrorAlert from '@/components/ApiErrorAlert'
 
 export default function App() {
   const ping = useSendPing()
@@ -28,11 +29,7 @@ export default function App() {
               </Button>
             </Group>
 
-            {ping.isError && (
-              <Alert color="red" variant="light" title="Request failed">
-                {ping.error.message}
-              </Alert>
-            )}
+            {ping.isError && <ApiErrorAlert error={ping.error} />}
 
             {ping.data && (
               <Stack gap="xs">

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,0 +1,63 @@
+export class ApiError extends Error {
+  readonly code: string
+  readonly status: number
+  readonly details?: Record<string, unknown>
+
+  constructor(code: string, message: string, status: number, details?: Record<string, unknown>) {
+    super(message)
+    this.name = 'ApiError'
+    this.code = code
+    this.status = status
+    this.details = details
+  }
+}
+
+type ApiErrorBody = {
+  code?: unknown
+  message?: unknown
+  details?: unknown
+}
+
+export async function requestJson<T>(input: RequestInfo | URL, init: RequestInit = {}): Promise<T> {
+  const headers = new Headers(init.headers)
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
+  const res = await fetch(input, {
+    ...init,
+    credentials: 'include',
+    headers,
+  })
+
+  if (!res.ok) {
+    throw await parseError(res)
+  }
+
+  // 204 No Content — caller's `T` should be `void`, but the cast is on them.
+  if (res.status === 204) return undefined as T
+  return (await res.json()) as T
+}
+
+async function parseError(res: Response): Promise<ApiError> {
+  const text = await res.text().catch(() => '')
+  if (text) {
+    try {
+      const body = JSON.parse(text) as ApiErrorBody
+      if (typeof body.code === 'string' && typeof body.message === 'string') {
+        return new ApiError(
+          body.code,
+          body.message,
+          res.status,
+          body.details as Record<string, unknown> | undefined,
+        )
+      }
+    } catch {
+      // fall through — non-JSON body (proxy error page, etc.)
+    }
+  }
+  return new ApiError(
+    'HTTP_ERROR',
+    `Request failed: ${res.status} ${res.statusText}`.trim(),
+    res.status,
+  )
+}

--- a/frontend/src/api/ping.ts
+++ b/frontend/src/api/ping.ts
@@ -1,5 +1,7 @@
 import { useMutation } from '@tanstack/react-query'
 
+import { requestJson } from '@/api/http'
+
 export type PingRequest = {
   message: string
 }
@@ -11,17 +13,10 @@ export type PingResponse = {
 }
 
 async function sendPing(req: PingRequest): Promise<PingResponse> {
-  const res = await fetch('/api/ping', {
+  return requestJson<PingResponse>('/api/ping', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
     body: JSON.stringify(req),
   })
-  if (!res.ok) {
-    const detail = await res.text().catch(() => '')
-    throw new Error(`Ping failed: ${res.status} ${res.statusText}${detail ? ` — ${detail}` : ''}`)
-  }
-  return (await res.json()) as PingResponse
 }
 
 export function useSendPing() {

--- a/frontend/src/components/ApiErrorAlert.tsx
+++ b/frontend/src/components/ApiErrorAlert.tsx
@@ -1,0 +1,27 @@
+import { Alert, Code, Group, Stack, Text } from '@mantine/core'
+
+import { ApiError } from '@/api/http'
+
+type ApiErrorAlertProps = {
+  error: unknown
+  title?: string
+}
+
+export default function ApiErrorAlert({ error, title = 'Request failed' }: ApiErrorAlertProps) {
+  const code = error instanceof ApiError ? error.code : null
+  const message = error instanceof Error ? error.message : String(error)
+
+  return (
+    <Alert color="red" variant="light" title={title}>
+      <Stack gap={4}>
+        {code && (
+          <Group gap="xs">
+            <Text size="sm" c="dimmed">code:</Text>
+            <Code>{code}</Code>
+          </Group>
+        )}
+        <Text size="sm">{message}</Text>
+      </Stack>
+    </Alert>
+  )
+}

--- a/server/src/main/kotlin/com/tcoverwatch/common/api/ApiErrorAdvice.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/api/ApiErrorAdvice.kt
@@ -1,0 +1,131 @@
+package com.tcoverwatch.common.api
+
+import com.tcoverwatch.common.exception.ConflictException
+import com.tcoverwatch.common.exception.FailedPreconditionException
+import com.tcoverwatch.common.exception.NotFoundException
+import com.tcoverwatch.common.exception.PermissionDeniedException
+import com.tcoverwatch.common.exception.UnauthenticatedException
+import com.tcoverwatch.common.exception.ValidationException
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.HttpMediaTypeNotAcceptableException
+import org.springframework.web.HttpMediaTypeNotSupportedException
+import org.springframework.web.HttpRequestMethodNotSupportedException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.servlet.resource.NoResourceFoundException
+
+@RestControllerAdvice
+class ApiErrorAdvice {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @ExceptionHandler(NotFoundException::class)
+    fun handleNotFound(e: NotFoundException) = respond(HttpStatus.NOT_FOUND, e.code, e.message)
+
+    @ExceptionHandler(PermissionDeniedException::class)
+    fun handlePermissionDenied(e: PermissionDeniedException) = respond(HttpStatus.FORBIDDEN, e.code, e.message)
+
+    @ExceptionHandler(UnauthenticatedException::class)
+    fun handleUnauthenticated(e: UnauthenticatedException) = respond(HttpStatus.UNAUTHORIZED, e.code, e.message)
+
+    @ExceptionHandler(ConflictException::class)
+    fun handleConflict(e: ConflictException) = respond(HttpStatus.CONFLICT, e.code, e.message)
+
+    @ExceptionHandler(FailedPreconditionException::class)
+    fun handleFailedPrecondition(e: FailedPreconditionException) = respond(HttpStatus.UNPROCESSABLE_ENTITY, e.code, e.message)
+
+    @ExceptionHandler(ValidationException::class)
+    fun handleValidation(e: ValidationException): ResponseEntity<ApiErrorResponse> {
+        val details =
+            e.fieldErrors?.let { errors ->
+                mapOf(
+                    "fieldErrors" to
+                        errors.map { fe ->
+                            mapOf(
+                                "field" to fe.field,
+                                "message" to fe.message,
+                                "rejectedValue" to fe.rejectedValue,
+                            )
+                        },
+                )
+            }
+        return respond(HttpStatus.BAD_REQUEST, e.code, e.message, details)
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleBeanValidation(e: MethodArgumentNotValidException): ResponseEntity<ApiErrorResponse> {
+        val fieldErrors =
+            e.bindingResult.fieldErrors.map { fe ->
+                mapOf(
+                    "field" to fe.field,
+                    "message" to (fe.defaultMessage ?: "invalid"),
+                    "rejectedValue" to fe.rejectedValue,
+                )
+            }
+        val summary =
+            fieldErrors
+                .firstOrNull()
+                ?.let { "${it["field"]}: ${it["message"]}" }
+                ?: "Request validation failed"
+        return respond(
+            status = HttpStatus.BAD_REQUEST,
+            code = "VALIDATION_FAILED",
+            message = summary,
+            details = mapOf("fieldErrors" to fieldErrors),
+        )
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleUnreadableBody(e: HttpMessageNotReadableException) =
+        respond(HttpStatus.BAD_REQUEST, "MALFORMED_REQUEST", "Request body could not be parsed")
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    fun handleMethodNotAllowed(e: HttpRequestMethodNotSupportedException) =
+        respond(HttpStatus.METHOD_NOT_ALLOWED, "METHOD_NOT_ALLOWED", e.message)
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException::class)
+    fun handleUnsupportedMediaType(e: HttpMediaTypeNotSupportedException) =
+        respond(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "UNSUPPORTED_MEDIA_TYPE", e.message)
+
+    @ExceptionHandler(HttpMediaTypeNotAcceptableException::class)
+    fun handleNotAcceptable(e: HttpMediaTypeNotAcceptableException) = respond(HttpStatus.NOT_ACCEPTABLE, "NOT_ACCEPTABLE", e.message)
+
+    @ExceptionHandler(MissingServletRequestParameterException::class)
+    fun handleMissingParameter(e: MissingServletRequestParameterException) = respond(HttpStatus.BAD_REQUEST, "MISSING_PARAMETER", e.message)
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleTypeMismatch(e: MethodArgumentTypeMismatchException) =
+        respond(HttpStatus.BAD_REQUEST, "TYPE_MISMATCH", "Parameter '${e.name}' has invalid type")
+
+    @ExceptionHandler(NoResourceFoundException::class)
+    fun handleNoResource(e: NoResourceFoundException) = respond(HttpStatus.NOT_FOUND, "NOT_FOUND", "Resource not found")
+
+    @ExceptionHandler(Exception::class)
+    fun handleUnknown(e: Exception): ResponseEntity<ApiErrorResponse> {
+        log.error("Unhandled exception", e)
+        return respond(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "Something went wrong")
+    }
+
+    private fun respond(
+        status: HttpStatus,
+        code: String,
+        message: String?,
+        details: Map<String, Any?>? = null,
+    ): ResponseEntity<ApiErrorResponse> {
+        if (status.is4xxClientError) {
+            log.info("Client error {} {} {}", status.value(), code, message)
+        }
+        return ResponseEntity.status(status).body(
+            ApiErrorResponse(
+                code = code,
+                message = message ?: status.reasonPhrase,
+                details = details,
+            ),
+        )
+    }
+}

--- a/server/src/main/kotlin/com/tcoverwatch/common/api/ApiErrorResponse.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/api/ApiErrorResponse.kt
@@ -1,0 +1,10 @@
+package com.tcoverwatch.common.api
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class ApiErrorResponse(
+    val code: String,
+    val message: String,
+    val details: Map<String, Any?>? = null,
+)

--- a/server/src/main/kotlin/com/tcoverwatch/common/exception/DomainExceptions.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/exception/DomainExceptions.kt
@@ -1,0 +1,48 @@
+package com.tcoverwatch.common.exception
+
+sealed class DomainException(
+    val code: String,
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)
+
+class NotFoundException(
+    message: String,
+    cause: Throwable? = null,
+) : DomainException(code = "NOT_FOUND", message = message, cause = cause)
+
+class PermissionDeniedException(
+    message: String,
+    cause: Throwable? = null,
+) : DomainException(code = "PERMISSION_DENIED", message = message, cause = cause)
+
+class UnauthenticatedException(
+    message: String,
+    cause: Throwable? = null,
+) : DomainException(code = "UNAUTHENTICATED", message = message, cause = cause)
+
+class ConflictException(
+    message: String,
+    cause: Throwable? = null,
+) : DomainException(code = "CONFLICT", message = message, cause = cause)
+
+// 422 Unprocessable Entity for business-state failures (closed transaction, expired invite).
+// 412 Precondition Failed is reserved for HTTP-level preconditions (If-Match etc.).
+class FailedPreconditionException(
+    message: String,
+    cause: Throwable? = null,
+) : DomainException(code = "FAILED_PRECONDITION", message = message, cause = cause)
+
+// Service-layer shape-validation failure. The controller's `@Valid` path uses Jakarta's
+// MethodArgumentNotValidException — mapped separately by the advice into the same envelope.
+class ValidationException(
+    message: String,
+    val fieldErrors: List<FieldError>? = null,
+    cause: Throwable? = null,
+) : DomainException(code = "VALIDATION_FAILED", message = message, cause = cause)
+
+data class FieldError(
+    val field: String,
+    val message: String,
+    val rejectedValue: Any? = null,
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,8 +7,10 @@ pluginManagement {
 
 plugins {
     // Enables Gradle toolchain auto-provisioning — downloads a JDK matching the
-    // toolchain spec (Java 21) when one isn't installed locally.
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    // toolchain spec when one isn't installed locally. 1.0.0+ is required for
+    // Gradle 9.x; earlier versions reference JvmVendorSpec.IBM_SEMERU which
+    // was renamed in Gradle 9.5 and fails at JDK-provisioning time on CI.
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "tc-overwatch"


### PR DESCRIPTION
## Summary

- Backend `@RestControllerAdvice` maps a sealed `DomainException` hierarchy + Spring's natural web exceptions to a typed envelope `{ code, message, details? }` (404/400/403/401/409/422 + 405/415/406/400/400/404 for Spring exceptions).
- Frontend `requestJson<T>` helper centralizes fetch boilerplate (Content-Type, credentials, envelope parsing) and surfaces failures as a typed `ApiError`. Reusable `<ApiErrorAlert>` renders the envelope.
- Docs: pin advice location + the `<ApiErrorAlert>` pattern in `docs/claude/{spring-boot,react}.md`.

Closes #82. Belongs to epic #13 (reopened to absorb cross-cutting setup follow-ups).

## Test plan

- [x] `./gradlew :server:build` clean
- [x] `npm --prefix frontend run build && run lint` clean
- [x] Six backend curl cases: 200 valid / 400 `VALIDATION_FAILED` / 405 `METHOD_NOT_ALLOWED` / 415 `UNSUPPORTED_MEDIA_TYPE` / 400 `MALFORMED_REQUEST` / 404 `NOT_FOUND` — all return correct envelopes
- [x] UI driven end-to-end via Playwright/Chrome: happy path renders, validation error through real backend renders `<ApiErrorAlert>` with `VALIDATION_FAILED` chip, synthetic 500 renders `INTERNAL_ERROR` chip, non-envelope 502 (HTML body) falls back to `HTTP_ERROR` chip

## Notes

- `FailedPreconditionException` → **422 Unprocessable Entity** (business-state failure). 412 reserved for HTTP-level preconditions.
- `requestJson` is the new pinned pattern in `docs/claude/react.md` § Backend calls. Future `src/api/<domain>.ts` files use it — never raw `fetch`.
- One cosmetic find from verification: backend `MethodArgumentNotValidException` summary format `"${field}: ${msg}"` renders `"message: must not be blank"` for ping (field literally named `message`). Won't recur for differently-named fields; not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)