### PR TITLE
Auth data foundation: tenant + app_user + invitation schemas

### DIFF
--- a/docs/claude/liquibase.md
+++ b/docs/claude/liquibase.md
@@ -1,11 +1,17 @@
 # Database Migrations
 
-Liquibase (Groovy DSL). Layout:
+Liquibase, two file formats — match the format to the kind of change:
+
+- **Groovy DSL** (`.groovy`) for table manipulations and basic data updates: `createTable`, `addColumn`, `addUniqueConstraint`, `createIndex`, `addForeignKeyConstraint`, INSERT/UPDATE data. Most changesets live here.
+- **Liquibase formatted SQL** (`.sql` with `--changeset` headers) for SQL-heavy migrations: functions, procedures, views, triggers, complex expression-based migrations. Native PostgreSQL syntax — no double-escaping through Groovy strings, IDE picks up SQL highlighting, `$$ ... $$` function bodies work without surprise.
+
+Layout:
 
 ```
 server/src/main/resources/db/changelog/
 ├── db.changelog-master.groovy        # list of include file: entries, in order
-├── changelog-001.groovy              # accumulates changesets
+├── fn-<name>.sql                     # function / procedure / view, runOnChange (own file per rule 5)
+├── changelog-001.groovy              # accumulates schema-change changesets
 ├── changelog-002.groovy              # next file once the previous gets large
 └── ...
 ```
@@ -44,7 +50,7 @@ The counter is a suffix, not a prefix, and the prefix is identical across the gr
 2. Never modify a committed changeset (`id` + `author` is the checksum key). New change → new changeset.
 3. One changeset per logical change.
 4. **No database enum types** — use `VARCHAR` and enforce values in app code. `ALTER TYPE ADD VALUE` can't run in a transaction and values can't be removed.
-5. Functions/views/policies that change in place: `runOnChange: true`, own file.
+5. Functions/views/policies that change in place: `runOnChange: true`, own `.sql` file (Liquibase formatted SQL — see Layout). When the body contains semicolons inside a `$$ ... $$` block, the changeset header needs `splitStatements:false` or Liquibase's default parser will break the dollar-quoted body.
 6. Tenant-scoped tables declare RLS in the same changeset as the table. No interim state.
 
 ## Tenant-scoped table template

--- a/scripts/db-init/01-roles.sql
+++ b/scripts/db-init/01-roles.sql
@@ -1,10 +1,14 @@
--- Local-dev DB role setup. Runs once at first Postgres container start.
+-- Local-dev DB role + schema setup. Runs once at first Postgres container start.
 --
 -- Mirrors the three-role pattern documented in docs/architecture.md § Multi-tenancy:
 --   tco_app     — no BYPASSRLS, used by the application for normal request-scoped work
 --   tco_admin   — has BYPASSRLS, used only via the explicit withAdminConnection { ... }
 --                 marker for tenant provisioning, admin RPCs, system-wide jobs
 --   tco_migrate — superuser-equivalent for DDL (Liquibase migrations)
+--
+-- Application data lives in the `tco` schema; `public` is reserved for Postgres
+-- extensions (pg_trgm, etc.). search_path on every role is set so queries use
+-- unqualified table names that resolve to `tco` first.
 --
 -- Production roles are provisioned through Cloud SQL IAM / Secret Manager, not this script.
 -- Passwords here are for LOCAL DEV ONLY.
@@ -14,14 +18,28 @@ CREATE ROLE tco_admin   LOGIN PASSWORD 'tco_admin_local_password' BYPASSRLS;
 CREATE ROLE tco_migrate LOGIN PASSWORD 'tco_migrate_local_password' SUPERUSER;
 
 GRANT CONNECT ON DATABASE tco TO tco_app, tco_admin, tco_migrate;
-GRANT USAGE, CREATE ON SCHEMA public TO tco_app, tco_admin, tco_migrate;
 
--- Default privileges so future migration-created objects are usable by the app role.
--- Run AS tco_migrate so future objects it creates are visible to tco_app by default.
-ALTER DEFAULT PRIVILEGES FOR ROLE tco_migrate IN SCHEMA public
+-- App data lives in `tco`. Owned by tco_migrate (the role that runs migrations in prod).
+CREATE SCHEMA tco AUTHORIZATION tco_migrate;
+GRANT USAGE, CREATE ON SCHEMA tco TO tco_app, tco_admin, tco_migrate;
+
+-- public stays for Postgres extensions. App + admin get USAGE so they can call
+-- extension functions; only migrate can CREATE there (future extension installs).
+GRANT USAGE ON SCHEMA public TO tco_app, tco_admin;
+GRANT USAGE, CREATE ON SCHEMA public TO tco_migrate;
+
+-- search_path: `tco` first so unqualified names resolve to app tables; `public`
+-- second so extension operators / functions remain accessible.
+ALTER ROLE tco_app     SET search_path = tco, public;
+ALTER ROLE tco_admin   SET search_path = tco, public;
+ALTER ROLE tco_migrate SET search_path = tco, public;
+
+-- Default privileges so future migration-created objects in `tco` are usable
+-- by the app role. Run AS tco_migrate so future objects it creates inherit these.
+ALTER DEFAULT PRIVILEGES FOR ROLE tco_migrate IN SCHEMA tco
     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO tco_app, tco_admin;
-ALTER DEFAULT PRIVILEGES FOR ROLE tco_migrate IN SCHEMA public
+ALTER DEFAULT PRIVILEGES FOR ROLE tco_migrate IN SCHEMA tco
     GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO tco_app, tco_admin;
 
--- Extensions used by future migrations (fuzzy text matching for address / name normalization).
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
+-- Extensions live in `public`. Installed once per database.
+CREATE EXTENSION IF NOT EXISTS pg_trgm SCHEMA public;

--- a/server/src/main/kotlin/com/tcoverwatch/common/auditing/AuditingConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/auditing/AuditingConfig.kt
@@ -1,0 +1,20 @@
+package com.tcoverwatch.common.auditing
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.domain.AuditorAware
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import java.util.Optional
+import java.util.UUID
+
+// Wires Spring's @CreatedBy / @LastModifiedBy / @CreatedDate / @LastModifiedDate on
+// entities annotated @EntityListeners(AuditingEntityListener::class).
+//
+// v0: AuditorAware returns Optional.empty() — no authenticated principal yet, so
+// created_by / updated_by stay NULL. Wire to the JWT-derived user id once PR 2 lands.
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorAware")
+class AuditingConfig {
+    @Bean
+    fun auditorAware(): AuditorAware<UUID> = AuditorAware { Optional.empty() }
+}

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/persistence/AppUser.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/persistence/AppUser.kt
@@ -1,0 +1,42 @@
+package com.tcoverwatch.feature.auth.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "app_user")
+@EntityListeners(AuditingEntityListener::class)
+class AppUser(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    var id: UUID? = null,
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    var createdBy: UUID? = null,
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant? = null,
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    var updatedBy: UUID? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant? = null,
+    @Column(name = "tenant_id", nullable = false, updatable = false)
+    var tenantId: UUID,
+    @Column(name = "email", nullable = false)
+    var email: String,
+)

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/persistence/AppUserRepository.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/persistence/AppUserRepository.kt
@@ -1,0 +1,11 @@
+package com.tcoverwatch.feature.auth.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface AppUserRepository : JpaRepository<AppUser, UUID> {
+    // tenant_id filter is implicit via RLS — never hand-filter on it. See architecture.md § Multi-tenancy.
+    fun findByEmail(email: String): AppUser?
+}

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/persistence/Invitation.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/persistence/Invitation.kt
@@ -1,0 +1,48 @@
+package com.tcoverwatch.feature.auth.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "invitation")
+@EntityListeners(AuditingEntityListener::class)
+class Invitation(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    var id: UUID? = null,
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    var createdBy: UUID? = null,
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant? = null,
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    var updatedBy: UUID? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant? = null,
+    @Column(name = "email", nullable = false)
+    var email: String,
+    @Column(name = "token", nullable = false, updatable = false)
+    var token: UUID = UUID.randomUUID(),
+    @Column(name = "expires_at")
+    var expiresAt: Instant? = null,
+    @Column(name = "accepted_at")
+    var acceptedAt: Instant? = null,
+    @Column(name = "tenant_id")
+    var tenantId: UUID? = null,
+)

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/persistence/InvitationRepository.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/persistence/InvitationRepository.kt
@@ -1,0 +1,13 @@
+package com.tcoverwatch.feature.auth.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface InvitationRepository : JpaRepository<Invitation, UUID> {
+    fun findByToken(token: UUID): Invitation?
+
+    // FIFO when an email has multiple pending invitations — auth gate picks the oldest.
+    fun findFirstByEmailAndAcceptedAtIsNullOrderByCreatedAtAsc(email: String): Invitation?
+}

--- a/server/src/main/kotlin/com/tcoverwatch/feature/tenant/persistence/Tenant.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/tenant/persistence/Tenant.kt
@@ -1,0 +1,38 @@
+package com.tcoverwatch.feature.tenant.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "tenant")
+@EntityListeners(AuditingEntityListener::class)
+class Tenant(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    var id: UUID? = null,
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    var createdBy: UUID? = null,
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant? = null,
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    var updatedBy: UUID? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant? = null,
+)

--- a/server/src/main/kotlin/com/tcoverwatch/feature/tenant/persistence/TenantRepository.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/tenant/persistence/TenantRepository.kt
@@ -1,0 +1,8 @@
+package com.tcoverwatch.feature.tenant.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface TenantRepository : JpaRepository<Tenant, UUID>

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -9,12 +9,14 @@ spring:
     driver-class-name: org.postgresql.Driver
 
   # In local dev, Liquibase runs at startup for convenience (no separate migrate container).
-  # NOTE: this uses the app DB user (tco_app), not the migrate role. Override in local docker-compose
-  # to run migrations as tco_migrate before the app starts if RLS gets in the way.
+  # Migrations run as tco_migrate so (a) tables are owned by a different role than
+  # the app uses, which means RLS actually filters tco_app's queries (owners
+  # bypass RLS by default), and (b) only tco_migrate has CREATE on public for
+  # Liquibase's own bookkeeping tables.
   liquibase:
     enabled: true
-    user: tco_app
-    password: tco_app_local_password
+    user: tco_migrate
+    password: tco_migrate_local_password
 
   jpa:
     show-sql: true

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -11,6 +11,11 @@ spring:
   # at app startup using the autoconfig default (enabled when on the classpath).
   liquibase:
     change-log: classpath:/db/changelog/db.changelog-master.groovy
+    # App data lives in `tco`. Liquibase's own bookkeeping tables
+    # (databasechangelog, databasechangeloglock) stay in `public` — they're
+    # framework infrastructure, not domain data.
+    default-schema: tco
+    liquibase-schema: public
 
   jpa:
     hibernate:
@@ -18,6 +23,7 @@ spring:
     properties:
       hibernate:
         format_sql: false
+        default_schema: tco   # entities resolve to `tco.<table>` without per-@Table annotation
     open-in-view: false    # avoid OSIV antipattern; DAOs return DTOs, not entities
 
   jackson:

--- a/server/src/main/resources/db/changelog/changelog-001.groovy
+++ b/server/src/main/resources/db/changelog/changelog-001.groovy
@@ -1,3 +1,5 @@
+package db.changelog
+
 // changelog-001 — accumulates v0 schema changesets. Append new changesets below;
 // see docs/claude/liquibase.md for naming + rotation rules.
 
@@ -23,6 +25,128 @@ databaseChangeLog {
 
         rollback {
             dropTable(tableName: 'ping_log')
+        }
+    }
+
+    changeSet(id: 'create-tenant-table', author: 'Christian Nau') {
+        comment 'Tenant — control-plane parent of multi-tenancy. No RLS (tenants ARE the tenancy boundary, not subject to it). Audit columns populated by Spring JPA auditing; no FK on created_by/updated_by because tenants exist before their first user.'
+
+        createTable(tableName: 'tenant') {
+            column(name: 'id', type: 'UUID', defaultValueComputed: 'gen_random_uuid()') {
+                constraints(primaryKey: true, nullable: false)
+            }
+            column(name: 'created_by', type: 'UUID') {
+                constraints(nullable: true)
+            }
+            column(name: 'created_at', type: 'TIMESTAMPTZ', defaultValueComputed: 'now()') {
+                constraints(nullable: false)
+            }
+            column(name: 'updated_by', type: 'UUID') {
+                constraints(nullable: true)
+            }
+            column(name: 'updated_at', type: 'TIMESTAMPTZ', defaultValueComputed: 'now()') {
+                constraints(nullable: false)
+            }
+        }
+
+        rollback {
+            dropTable(tableName: 'tenant')
+        }
+    }
+
+    changeSet(id: 'create-app-user-table', author: 'Christian Nau') {
+        comment 'AppUser — tenant-scoped, RLS-protected. One user per tenant in v0; multi-user-per-tenant is BACKLOG. Audit columns populated by Spring JPA auditing; no FK on created_by/updated_by (a user can be the creator of itself at invitation acceptance).'
+
+        createTable(tableName: 'app_user') {
+            column(name: 'id', type: 'UUID', defaultValueComputed: 'gen_random_uuid()') {
+                constraints(primaryKey: true, nullable: false)
+            }
+            column(name: 'created_by', type: 'UUID') {
+                constraints(nullable: true)
+            }
+            column(name: 'created_at', type: 'TIMESTAMPTZ', defaultValueComputed: 'now()') {
+                constraints(nullable: false)
+            }
+            column(name: 'updated_by', type: 'UUID') {
+                constraints(nullable: true)
+            }
+            column(name: 'updated_at', type: 'TIMESTAMPTZ', defaultValueComputed: 'now()') {
+                constraints(nullable: false)
+            }
+            column(name: 'tenant_id', type: 'UUID') {
+                constraints(nullable: false, foreignKeyName: 'fk_app_user_tenant', references: 'tenant(id)')
+            }
+            column(name: 'email', type: 'TEXT') {
+                constraints(nullable: false)
+            }
+        }
+
+        addUniqueConstraint(
+            tableName: 'app_user',
+            columnNames: 'tenant_id, email',
+            constraintName: 'uq_app_user_tenant_email',
+        )
+
+        createIndex(tableName: 'app_user', indexName: 'idx_app_user_tenant_id') {
+            column(name: 'tenant_id')
+        }
+
+        sql "SELECT tco.enable_tenant_isolation('app_user');"
+
+        rollback {
+            sql "SELECT tco.disable_tenant_isolation('app_user');"
+            dropTable(tableName: 'app_user')
+        }
+    }
+
+    changeSet(id: 'create-invitation-table', author: 'Christian Nau') {
+        comment 'Invitation — control-plane (NOT tenant-scoped, NO RLS). Pre-acceptance: tenant_id and accepted_at are NULL. v0: admin creates by direct DB insert; auth gate matches by email pre-acceptance. Audit columns populated by Spring JPA auditing; created_by keeps its FK to app_user(id).'
+
+        createTable(tableName: 'invitation') {
+            column(name: 'id', type: 'UUID', defaultValueComputed: 'gen_random_uuid()') {
+                constraints(primaryKey: true, nullable: false)
+            }
+            column(name: 'created_by', type: 'UUID') {
+                constraints(nullable: true, foreignKeyName: 'fk_invitation_created_by', references: 'app_user(id)')
+            }
+            column(name: 'created_at', type: 'TIMESTAMPTZ', defaultValueComputed: 'now()') {
+                constraints(nullable: false)
+            }
+            column(name: 'updated_by', type: 'UUID') {
+                constraints(nullable: true)
+            }
+            column(name: 'updated_at', type: 'TIMESTAMPTZ', defaultValueComputed: 'now()') {
+                constraints(nullable: false)
+            }
+            column(name: 'email', type: 'TEXT') {
+                constraints(nullable: false)
+            }
+            column(name: 'token', type: 'UUID', defaultValueComputed: 'gen_random_uuid()') {
+                constraints(nullable: false)
+            }
+            column(name: 'expires_at', type: 'TIMESTAMPTZ') {
+                constraints(nullable: true)
+            }
+            column(name: 'accepted_at', type: 'TIMESTAMPTZ') {
+                constraints(nullable: true)
+            }
+            column(name: 'tenant_id', type: 'UUID') {
+                constraints(nullable: true, foreignKeyName: 'fk_invitation_tenant', references: 'tenant(id)')
+            }
+        }
+
+        addUniqueConstraint(
+            tableName: 'invitation',
+            columnNames: 'token',
+            constraintName: 'uq_invitation_token',
+        )
+
+        // Partial index — only pending invitations get looked up by email at the auth gate.
+        sql 'CREATE INDEX idx_invitation_pending_email ON invitation (email) WHERE accepted_at IS NULL;'
+
+        rollback {
+            sql 'DROP INDEX IF EXISTS idx_invitation_pending_email;'
+            dropTable(tableName: 'invitation')
         }
     }
 }

--- a/server/src/main/resources/db/changelog/db.changelog-master.groovy
+++ b/server/src/main/resources/db/changelog/db.changelog-master.groovy
@@ -1,3 +1,8 @@
+package db.changelog
+
 databaseChangeLog {
+    // Functions/views (runOnChange) first so they exist when later changesets call them.
+    include file: 'fn-tenant-isolation.sql', relativeToChangelogFile: true
+
     include file: 'changelog-001.groovy', relativeToChangelogFile: true
 }

--- a/server/src/main/resources/db/changelog/fn-tenant-isolation.sql
+++ b/server/src/main/resources/db/changelog/fn-tenant-isolation.sql
@@ -1,0 +1,36 @@
+--liquibase formatted sql
+
+-- Helper functions for the project-standard tenant_isolation RLS policy. Called from
+-- every tenant-scoped table's create / drop changesets so the policy text lives in
+-- exactly one place. Per docs/claude/liquibase.md: SQL-heavy changesets (functions,
+-- procedures, views, triggers) use Liquibase formatted SQL — Groovy DSL is for table
+-- manipulations and basic updates.
+
+--changeset Christian Nau:fn-tenant-isolation runOnChange:true splitStatements:false
+--comment: enable_tenant_isolation(regclass) + disable_tenant_isolation(regclass) — apply / remove the tenant_isolation RLS policy on a tenant-scoped table.
+
+CREATE OR REPLACE FUNCTION tco.enable_tenant_isolation(target_table regclass)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    EXECUTE format('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', target_table);
+    EXECUTE format(
+        'CREATE POLICY tenant_isolation ON %s USING (tenant_id = current_setting(''app.tenant_id'', true)::uuid)',
+        target_table
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION tco.disable_tenant_isolation(target_table regclass)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    EXECUTE format('DROP POLICY IF EXISTS tenant_isolation ON %s', target_table);
+    EXECUTE format('ALTER TABLE %s DISABLE ROW LEVEL SECURITY', target_table);
+END;
+$$;
+
+--rollback DROP FUNCTION IF EXISTS tco.enable_tenant_isolation(regclass);
+--rollback DROP FUNCTION IF EXISTS tco.disable_tenant_isolation(regclass);


### PR DESCRIPTION
First PR in the access-control epic (#18). Schema + JPA entities + repositories + auditing wiring. No HTTP / security yet — stub login + JWT cookie land in PR 2.

## Summary

- Three new tables in a new `tco` schema: `tenant`, `app_user`, `invitation` (each with full audit columns).
- `tco` schema split: app data in `tco`, Postgres extensions + Liquibase bookkeeping in `public`.
- Local migrations switched from `tco_app` → `tco_migrate` — RLS now actually filters in local dev (verified).
- Liquibase formatted SQL convention pinned for SQL-heavy migrations (functions/views/triggers).
- `tco.enable_tenant_isolation(regclass)` / `tco.disable_tenant_isolation(regclass)` helper functions so future tenant-scoped tables don't repeat the policy text.

Belongs to epic #18.

## Test plan

- [x] `./gradlew :server:build` clean
- [x] All 5 changesets apply on a fresh DB; Hibernate validates the schema
- [x] App tables (`tco.tenant`, `tco.app_user`, `tco.invitation`, `tco.ping_log`) owned by `tco_migrate`
- [x] Liquibase bookkeeping in `public`; `pg_trgm` in `public`; `gen_random_uuid()` in `pg_catalog`
- [x] **RLS actually filters in local dev**: `tco_app` sees 0/1/0 rows for (no tenant set / correct tenant / wrong tenant); `tco_admin` (BYPASSRLS) sees the row regardless
- [x] `findByEmail` repository query relies on RLS for tenant filtering, no hand-written `WHERE tenant_id = ?`

## Notes

- **Audit fields populated via Spring JPA auditing** with `@CreatedBy`/`@CreatedDate`/`@LastModifiedBy`/`@LastModifiedDate`. v0 `AuditorAware<UUID>` returns `Optional.empty()` — wire to JWT-derived user id in PR 2.
- **FK strategy:** `invitation.created_by` keeps FK to `app_user(id)`; `tenant.created_by` and `app_user.created_by` are plain nullable UUIDs (chicken-and-egg at invitation acceptance: tenant is created before its first user).
- **`Invitation.token`** generates client-side via `UUID.randomUUID()` default; DB's `gen_random_uuid()` default is the belt-and-suspenders path for raw SQL inserts.
- **Migration file formats pinned in `docs/claude/liquibase.md`:** Groovy DSL for table manipulations; Liquibase formatted SQL (`.sql` with `--changeset` headers + `splitStatements:false`) for SQL-heavy work.
- **Local-dev migrations as `tco_migrate`** closes the pre-existing "RLS not tested locally" gap (acknowledged in the previous `application-local.yml` comment).

## Out of scope

- Spring Security + JWT cookie + stub login form → PR 2 of #18
- Auth gate + invitation acceptance flow → PR 3 of #18
- Tenant context propagation (request → `SET LOCAL app.tenant_id`) + invitation admin utility → PR 4 of #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)