### PR TITLE
Auth: Spring Security + JWT cookie + dev-only stub login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ replay_pid*.log
 node_modules/
 
 # ── IDE ───────────────────────────────────────────────────────────────────
+# .idea: user-specific IntelliJ state. Shared run configs live in .run/ (tracked).
 .idea/
 .vscode/
 .fleet/

--- a/.run/backend.run.xml
+++ b/.run/backend.run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Backend" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="--args=&quot;--spring.profiles.active=local&quot;" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":server:bootRun" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Postgres" run_configuration_type="ShConfigurationType" />
+    </method>
+  </configuration>
+</component>

--- a/.run/frontend.run.xml
+++ b/.run/frontend.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Frontend" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/frontend/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="dev" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/local-stack.run.xml
+++ b/.run/local-stack.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Local Stack" type="CompoundRunConfigurationType">
+    <toRun name="Backend" type="GradleRunConfiguration" />
+    <toRun name="Frontend" type="js.build_tools.npm" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/postgres-up.run.xml
+++ b/.run/postgres-up.run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Postgres" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="docker compose -f docker-compose.local.yml up -d --wait" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,9 +74,12 @@ If a future service-to-service caller actually needs a typed RPC contract, revis
 
 ### Authentication / Security
 
-- **Spring Security** with OAuth2 client for Google sign-in.
-- Refresh tokens are encrypted at the application layer with a KEK (from Secret Manager on GCP / `.env` on Unraid) before persisting to Postgres.
-- Session = HTTP-only Secure SameSite=Lax cookie holding an opaque session token; backend validates server-side.
+- **Spring Security** (Spring Security 7, paired with Spring Boot 4) — current wiring is the JWT-cookie path; will gain Google OAuth2 client on top in a later PR.
+- **Session = HTTP-only `SameSite=Lax` cookie (`tco_session`)** carrying an HS256-signed JWT with `email`, optional `userId`, optional `tenantId`. Backend validates on every request via a filter that populates the `SecurityContext` with an `AuthenticatedPrincipal`. `Secure` flag is config-driven (false in local, true in unraid/prod).
+- **JWT signing secret** comes from config (`auth.jwt.secret`) — env var / Secret Manager in non-local profiles, hardcoded local-only value in `application-local.yml`. HS256 today; revisit RS256 + JWKS if cross-service token validation ever becomes a need.
+- **Stub login** (`POST /api/auth/dev-login`) is profile-gated to `local` — accepts any well-formed email and mints a JWT. Replaced by the real OAuth callback + invitation gate when those land.
+- **Refresh tokens** (Google's) will be encrypted at the application layer with a KEK (from Secret Manager on GCP / `.env` on Unraid) before persisting to Postgres. Not yet wired — the stub auth path has no refresh tokens to store.
+- **No CSRF tokens** in v0 — `SameSite=Lax` + the SPA's same-parent-domain layout is the defense. Revisit if a third-party form-post surface ever lands.
 
 ### Multi-tenancy in the request pipeline
 

--- a/docs/claude/spring-boot.md
+++ b/docs/claude/spring-boot.md
@@ -147,6 +147,16 @@ internal fun Foo.toDto(): FooDto =
 
 Three profiles only: `local`, `unraid`, `prod`. Profile selection drives DB connection / secret source / OAuth client ID. Secrets come from env vars / Secret Manager / `.env` — never checked in. Adding a fourth profile needs a real architectural reason.
 
+## Security
+
+Strategy + cookie/JWT shape pinned in `architecture.md` § Authentication / Security. Operational rules:
+
+- `com.tcoverwatch.common.security.SecurityConfig` owns the single `SecurityFilterChain`. `JwtAuthenticationFilter` reads the `tco_session` cookie, validates via `JwtService.verify`, and populates `SecurityContextHolder` with a `JwtAuthenticationToken` whose principal is `AuthenticatedPrincipal(email, userId?, tenantId?)`.
+- Controllers read the principal via `@AuthenticationPrincipal principal: AuthenticatedPrincipal?` — never reach into `SecurityContextHolder` directly.
+- 401 / 403 from the security filter chain delegates to Spring MVC's `HandlerExceptionResolver` (via `@Lazy`-injected bean), which routes through `ApiErrorAdvice` so the response shape matches every other error envelope. Don't duplicate JSON serialization in the security layer.
+- `/api/auth/*` is the auth surface. Production endpoints (`/api/auth/me`, `/api/auth/logout`) live in `AuthController`. The stub login (`/api/auth/dev-login`) lives in a separate `DevAuthController` annotated `@Profile("local")` so it doesn't exist as a bean outside local dev.
+- Profile-gated controllers go in their own file — never mix `@Profile("local")` and unconditional `@RestController` classes in the same file. Different lifetimes deserve different files.
+
 ## Anti-patterns
 
 - Returning entities from controllers or services.

--- a/docs/claude/spring-boot.md
+++ b/docs/claude/spring-boot.md
@@ -14,6 +14,7 @@ Controller → Service → DAO → Repository → Database. Strategic detail in 
 - Request/response DTOs are Kotlin `data class`es co-located with the controller. Jackson handles (de)serialization automatically.
 - `@Valid` on the request DTO + Jakarta Bean Validation annotations (`@NotBlank`, `@Size`, `@Email`, etc.) on its fields. Shape validation only — no DB queries.
 - Convert request DTO → service DTO via the api-mapper extension, call service, convert response.
+- **Return the response DTO directly. Never wrap in `ResponseEntity<…>`.** Status code is declared explicitly via `@ResponseStatus(HttpStatus.X)` on the method — including `HttpStatus.OK` for success endpoints. Side effects on the response (cookies, custom headers) inject `HttpServletResponse` as a method parameter and call `response.addHeader(…)`. The status is visible at the method signature; the response shape is the DTO; no inline `ResponseEntity` plumbing.
 - Service exceptions propagate; `com.tcoverwatch.common.api.ApiErrorAdvice` maps each `DomainException` subclass (in `com.tcoverwatch.common.exception`) to a status code. Don't catch in the controller.
 
 | Exception | Status | `code` |
@@ -160,6 +161,7 @@ Strategy + cookie/JWT shape pinned in `architecture.md` § Authentication / Secu
 ## Anti-patterns
 
 - Returning entities from controllers or services.
+- Wrapping controller responses in `ResponseEntity` — return the DTO, use `@ResponseStatus` for the code and `HttpServletResponse` for header side effects.
 - Skipping a layer (controller → DAO, service → repository).
 - Manual `WHERE tenant_id = ?` filters — RLS does it.
 - Catching exceptions in the controller — let the advisor map them.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,55 +1,90 @@
-import { Container, Stack, Group, Title, Text, Button, Card, Badge, Code } from '@mantine/core'
+import {
+  Badge,
+  Button,
+  Card,
+  Center,
+  Code,
+  Container,
+  Group,
+  Loader,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core'
 
+import { useMe } from '@/api/auth'
 import { useSendPing } from '@/api/ping'
 import ApiErrorAlert from '@/components/ApiErrorAlert'
+import DevLoginCard from '@/components/DevLoginCard'
+import UserBadge from '@/components/UserBadge'
 
 export default function App() {
-  const ping = useSendPing()
+  const me = useMe()
 
   return (
     <Container size="sm" py="xl">
       <Stack gap="lg">
         <Group justify="space-between" align="baseline">
           <Title order={1}>tc-overwatch</Title>
-          <Badge color="blue" variant="light">scaffold</Badge>
+          {me.data ? <UserBadge me={me.data} /> : <Badge color="blue" variant="light">scaffold</Badge>}
         </Group>
 
-        <Text c="dimmed">
-          End-to-end smoke test. Click the button to <Code>POST /api/ping</Code> with a JSON
-          body. The backend writes a row to <Code>ping_log</Code> and echoes back the server
-          timestamp and DB-assigned id.
-        </Text>
+        {me.isPending && (
+          <Center>
+            <Loader />
+          </Center>
+        )}
 
-        <Card withBorder radius="md" p="lg">
-          <Stack gap="md">
-            <Group justify="space-between">
-              <Text fw={500}>Ping</Text>
-              <Button onClick={() => ping.mutate({ message: 'hello' })} loading={ping.isPending}>
-                Send ping
-              </Button>
-            </Group>
+        {me.isError && <ApiErrorAlert error={me.error} title="Couldn't load session" />}
 
-            {ping.isError && <ApiErrorAlert error={ping.error} />}
+        {!me.isPending && !me.data && <DevLoginCard />}
 
-            {ping.data && (
-              <Stack gap="xs">
-                <Group gap="xs">
-                  <Text size="sm" c="dimmed">echo:</Text>
-                  <Code>{ping.data.echo}</Code>
-                </Group>
-                <Group gap="xs">
-                  <Text size="sm" c="dimmed">serverReceivedAt:</Text>
-                  <Code>{ping.data.serverReceivedAt}</Code>
-                </Group>
-                <Group gap="xs">
-                  <Text size="sm" c="dimmed">id:</Text>
-                  <Code>{ping.data.id}</Code>
-                </Group>
-              </Stack>
-            )}
-          </Stack>
-        </Card>
+        {me.data && <PingCard />}
       </Stack>
     </Container>
+  )
+}
+
+function PingCard() {
+  const ping = useSendPing()
+
+  return (
+    <>
+      <Text c="dimmed">
+        End-to-end smoke test. Click the button to <Code>POST /api/ping</Code> with a JSON
+        body. The backend writes a row to <Code>ping_log</Code> and echoes back the server
+        timestamp and DB-assigned id.
+      </Text>
+
+      <Card withBorder radius="md" p="lg">
+        <Stack gap="md">
+          <Group justify="space-between">
+            <Text fw={500}>Ping</Text>
+            <Button onClick={() => ping.mutate({ message: 'hello' })} loading={ping.isPending}>
+              Send ping
+            </Button>
+          </Group>
+
+          {ping.isError && <ApiErrorAlert error={ping.error} />}
+
+          {ping.data && (
+            <Stack gap="xs">
+              <Group gap="xs">
+                <Text size="sm" c="dimmed">echo:</Text>
+                <Code>{ping.data.echo}</Code>
+              </Group>
+              <Group gap="xs">
+                <Text size="sm" c="dimmed">serverReceivedAt:</Text>
+                <Code>{ping.data.serverReceivedAt}</Code>
+              </Group>
+              <Group gap="xs">
+                <Text size="sm" c="dimmed">id:</Text>
+                <Code>{ping.data.id}</Code>
+              </Group>
+            </Stack>
+          )}
+        </Stack>
+      </Card>
+    </>
   )
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { ApiError, requestJson } from '@/api/http'
+import type { components } from '@/gen/api'
+
+export type MeResponse = components['schemas']['MeResponse']
+export type DevLoginRequest = components['schemas']['DevLoginRequest']
+
+const authKeys = {
+  me: ['auth', 'me'] as const,
+}
+
+// 401 from /api/auth/me is the expected "not signed in" signal — surface it as
+// `null` data instead of letting it propagate as a query error.
+async function fetchMe(): Promise<MeResponse | null> {
+  try {
+    return await requestJson<MeResponse>('/api/auth/me')
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 401) return null
+    throw e
+  }
+}
+
+async function devLogin(req: DevLoginRequest): Promise<MeResponse> {
+  return requestJson<MeResponse>('/api/auth/dev-login', {
+    method: 'POST',
+    body: JSON.stringify(req),
+  })
+}
+
+async function logout(): Promise<void> {
+  await requestJson<void>('/api/auth/logout', { method: 'POST' })
+}
+
+export const useMe = () => useQuery({ queryKey: authKeys.me, queryFn: fetchMe })
+
+export function useDevLogin() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: devLogin,
+    onSuccess: () => qc.invalidateQueries({ queryKey: authKeys.me }),
+  })
+}
+
+export function useLogout() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => qc.setQueryData(authKeys.me, null),
+  })
+}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -10,8 +10,7 @@ const authKeys = {
   me: ['auth', 'me'] as const,
 }
 
-// 401 from /api/auth/me is the expected "not signed in" signal — surface it as
-// `null` data instead of letting it propagate as a query error.
+// 401 → null data, not error. Signed-out is expected, not exceptional.
 async function fetchMe(): Promise<MeResponse | null> {
   try {
     return await requestJson<MeResponse>('/api/auth/me')

--- a/frontend/src/components/DevLoginCard.tsx
+++ b/frontend/src/components/DevLoginCard.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { Button, Card, Stack, Text, TextInput, Title } from '@mantine/core'
+
+import { useDevLogin } from '@/api/auth'
+import ApiErrorAlert from '@/components/ApiErrorAlert'
+
+export default function DevLoginCard() {
+  const [email, setEmail] = useState('')
+  const login = useDevLogin()
+
+  return (
+    <Card withBorder radius="md" p="lg">
+      <Stack gap="md">
+        <Title order={3}>Sign in</Title>
+        <Text size="sm" c="dimmed">
+          Dev-only stub — any well-formed email is accepted. Google OAuth lands in a later PR.
+        </Text>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            login.mutate({ email })
+          }}
+        >
+          <Stack gap="sm">
+            <TextInput
+              label="Email"
+              placeholder="alice@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.currentTarget.value)}
+              required
+              type="email"
+              autoFocus
+            />
+            <Button type="submit" loading={login.isPending}>
+              Sign in (dev)
+            </Button>
+          </Stack>
+        </form>
+        {login.isError && <ApiErrorAlert error={login.error} title="Sign-in failed" />}
+      </Stack>
+    </Card>
+  )
+}

--- a/frontend/src/components/UserBadge.tsx
+++ b/frontend/src/components/UserBadge.tsx
@@ -1,0 +1,30 @@
+import { Button, Group, Text } from '@mantine/core'
+
+import { useLogout } from '@/api/auth'
+import type { MeResponse } from '@/api/auth'
+
+type UserBadgeProps = {
+  me: MeResponse
+}
+
+export default function UserBadge({ me }: UserBadgeProps) {
+  const logout = useLogout()
+  return (
+    <Group gap="sm">
+      <Text size="sm" c="dimmed">
+        Signed in as{' '}
+        <Text component="span" fw={500} c="bright">
+          {me.email ?? 'unknown'}
+        </Text>
+      </Text>
+      <Button
+        size="xs"
+        variant="subtle"
+        onClick={() => logout.mutate()}
+        loading={logout.isPending}
+      >
+        Sign out
+      </Button>
+    </Group>
+  )
+}

--- a/frontend/src/gen/api.d.ts
+++ b/frontend/src/gen/api.d.ts
@@ -134,8 +134,8 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description OK */
-            200: {
+            /** @description No Content */
+            204: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/gen/api.d.ts
+++ b/frontend/src/gen/api.d.ts
@@ -20,6 +20,54 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["logout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/dev-login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["devLogin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["me"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -32,6 +80,17 @@ export interface components {
             serverReceivedAt?: string;
             /** Format: uuid */
             id?: string;
+        };
+        DevLoginRequest: {
+            /** Format: email */
+            email: string;
+        };
+        MeResponse: {
+            email?: string;
+            /** Format: uuid */
+            userId?: string | null;
+            /** Format: uuid */
+            tenantId?: string | null;
         };
     };
     responses: never;
@@ -62,6 +121,68 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PingResponse"];
+                };
+            };
+        };
+    };
+    logout: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    devLogin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DevLoginRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MeResponse"];
+                };
+            };
+        };
+    };
+    me: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MeResponse"];
                 };
             };
         };

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ springBoot-starter-oauth2-client    = { module = "org.springframework.boot:sprin
 springBoot-starter-data-jpa         = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
 springBoot-starter-actuator         = { module = "org.springframework.boot:spring-boot-starter-actuator" }
 springBoot-starter-validation       = { module = "org.springframework.boot:spring-boot-starter-validation" }
+springBoot-starter-oauth2-resource-server = { module = "org.springframework.boot:spring-boot-starter-oauth2-resource-server" }
 springBoot-starter-test             = { module = "org.springframework.boot:spring-boot-starter-test" }
 
 # OpenAPI / Swagger UI — walks @RestControllers, Jackson + Bean Validation annotations,

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -38,6 +38,10 @@ dependencies {
     implementation(libs.springBoot.starter.data.jpa)
     implementation(libs.springBoot.starter.actuator)
     implementation(libs.springBoot.starter.validation)
+    implementation(libs.springBoot.starter.security)
+    // JWT encoder/decoder beans. Pulled in for the stub auth path; the same module
+    // covers Google OAuth resource-server validation when real OAuth lands.
+    implementation(libs.springBoot.starter.oauth2.resource.server)
 
     // OpenAPI 3 spec + Swagger UI. Auto-walks @RestControllers — no annotations required
     // on existing code. See docs/claude/spring-boot.md § OpenAPI for the field-doc convention.

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/AuthCookie.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/AuthCookie.kt
@@ -1,0 +1,39 @@
+package com.tcoverwatch.common.security
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseCookie
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+const val SESSION_COOKIE_NAME = "tco_session"
+
+// Centralizes the cookie attributes so login / logout / future refresh flows
+// can't drift. `secure` is config-driven — false in local (over plain HTTP),
+// true in unraid / prod (over HTTPS at the Cloudflare edge).
+@Component
+class AuthCookie(
+    @Value("\${auth.cookie.secure}") private val secure: Boolean,
+    @Value("\${auth.jwt.token-lifetime}") private val tokenLifetime: Duration,
+) {
+    fun set(token: String): String =
+        ResponseCookie
+            .from(SESSION_COOKIE_NAME, token)
+            .httpOnly(true)
+            .secure(secure)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(tokenLifetime)
+            .build()
+            .toString()
+
+    fun clear(): String =
+        ResponseCookie
+            .from(SESSION_COOKIE_NAME, "")
+            .httpOnly(true)
+            .secure(secure)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(0)
+            .build()
+            .toString()
+}

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/AuthCookie.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/AuthCookie.kt
@@ -7,9 +7,6 @@ import java.time.Duration
 
 const val SESSION_COOKIE_NAME = "tco_session"
 
-// Centralizes the cookie attributes so login / logout / future refresh flows
-// can't drift. `secure` is config-driven — false in local (over plain HTTP),
-// true in unraid / prod (over HTTPS at the Cloudflare edge).
 @Component
 class AuthCookie(
     @Value("\${auth.cookie.secure}") private val secure: Boolean,

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/AuthenticatedPrincipal.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/AuthenticatedPrincipal.kt
@@ -2,10 +2,6 @@ package com.tcoverwatch.common.security
 
 import java.util.UUID
 
-// What the SecurityContext.authentication.principal holds after the JWT filter
-// fires. userId / tenantId are null in the stub-auth path (no user record exists
-// until invitation acceptance); they get populated once real OAuth + invitation
-// flow are wired (PR 3 of #18).
 data class AuthenticatedPrincipal(
     val email: String,
     val userId: UUID? = null,

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/AuthenticatedPrincipal.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/AuthenticatedPrincipal.kt
@@ -1,0 +1,13 @@
+package com.tcoverwatch.common.security
+
+import java.util.UUID
+
+// What the SecurityContext.authentication.principal holds after the JWT filter
+// fires. userId / tenantId are null in the stub-auth path (no user record exists
+// until invitation acceptance); they get populated once real OAuth + invitation
+// flow are wired (PR 3 of #18).
+data class AuthenticatedPrincipal(
+    val email: String,
+    val userId: UUID? = null,
+    val tenantId: UUID? = null,
+)

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/JwtAuthenticationFilter.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/JwtAuthenticationFilter.kt
@@ -1,0 +1,53 @@
+package com.tcoverwatch.common.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtService: JwtService,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val token = request.cookies?.firstOrNull { it.name == SESSION_COOKIE_NAME }?.value
+        if (token != null) {
+            jwtService.verify(token)?.let { jwt ->
+                // email is the one always-present claim (see JwtService.mint). A missing
+                // value means a corrupted / future-incompatible token — treat as anonymous
+                // rather than NPE'ing on the non-null principal field.
+                val email = jwt.getClaim<String?>("email")
+                if (email != null) {
+                    val principal =
+                        AuthenticatedPrincipal(
+                            email = email,
+                            userId = jwt.getClaim<String?>("userId")?.let(UUID::fromString),
+                            tenantId = jwt.getClaim<String?>("tenantId")?.let(UUID::fromString),
+                        )
+                    SecurityContextHolder.getContext().authentication = JwtAuthenticationToken(principal)
+                }
+            }
+        }
+        filterChain.doFilter(request, response)
+    }
+}
+
+class JwtAuthenticationToken(
+    private val authenticatedPrincipal: AuthenticatedPrincipal,
+) : AbstractAuthenticationToken(emptyList()) {
+    init {
+        isAuthenticated = true
+    }
+
+    override fun getCredentials(): Any? = null
+
+    override fun getPrincipal(): AuthenticatedPrincipal = authenticatedPrincipal
+}

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/JwtAuthenticationFilter.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/JwtAuthenticationFilter.kt
@@ -21,9 +21,7 @@ class JwtAuthenticationFilter(
         val token = request.cookies?.firstOrNull { it.name == SESSION_COOKIE_NAME }?.value
         if (token != null) {
             jwtService.verify(token)?.let { jwt ->
-                // email is the one always-present claim (see JwtService.mint). A missing
-                // value means a corrupted / future-incompatible token — treat as anonymous
-                // rather than NPE'ing on the non-null principal field.
+                // Missing email = corrupted/incompatible token. Treat as anonymous, don't NPE the principal.
                 val email = jwt.getClaim<String?>("email")
                 if (email != null) {
                     val principal =

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/JwtConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/JwtConfig.kt
@@ -1,0 +1,45 @@
+package com.tcoverwatch.common.security
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.OctetSequenceKey
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet
+import com.nimbusds.jose.jwk.source.JWKSource
+import com.nimbusds.jose.proc.SecurityContext
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.JwtEncoder
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder
+import javax.crypto.spec.SecretKeySpec
+
+// HS256 symmetric signing. Secret comes from config (auth.jwt.secret).
+// Prod sets it via env var / Secret Manager; local has a hardcoded value in
+// application-local.yml. The encoder + decoder beans are also what real OAuth
+// (Google) would consume, so this wiring is reusable.
+@Configuration
+class JwtConfig {
+    @Bean
+    fun jwtEncoder(
+        @Value("\${auth.jwt.secret}") secret: String,
+    ): JwtEncoder {
+        val jwk =
+            OctetSequenceKey
+                .Builder(secret.toByteArray(Charsets.UTF_8))
+                .algorithm(JWSAlgorithm.HS256)
+                .build()
+        val jwkSource: JWKSource<SecurityContext> = ImmutableJWKSet(JWKSet(jwk))
+        return NimbusJwtEncoder(jwkSource)
+    }
+
+    @Bean
+    fun jwtDecoder(
+        @Value("\${auth.jwt.secret}") secret: String,
+    ): JwtDecoder {
+        val key = SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256")
+        return NimbusJwtDecoder.withSecretKey(key).macAlgorithm(MacAlgorithm.HS256).build()
+    }
+}

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/JwtConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/JwtConfig.kt
@@ -16,10 +16,6 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder
 import javax.crypto.spec.SecretKeySpec
 
-// HS256 symmetric signing. Secret comes from config (auth.jwt.secret).
-// Prod sets it via env var / Secret Manager; local has a hardcoded value in
-// application-local.yml. The encoder + decoder beans are also what real OAuth
-// (Google) would consume, so this wiring is reusable.
 @Configuration
 class JwtConfig {
     @Bean

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/JwtService.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/JwtService.kt
@@ -32,9 +32,7 @@ class JwtService(
         val claims =
             JwtClaimsSet
                 .builder()
-                // `sub` always holds email — the one identity attribute present on every
-                // token, whether the user record exists yet (post-invitation-acceptance)
-                // or not (stub-auth path). `userId` / `tenantId` are separate claims.
+                // `sub` is email, not userId — email is the one claim present on every token.
                 .subject(email)
                 .claim("email", email)
                 .apply {

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/JwtService.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/JwtService.kt
@@ -1,0 +1,57 @@
+package com.tcoverwatch.common.security
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm
+import org.springframework.security.oauth2.jwt.JwsHeader
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtClaimsSet
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.JwtEncoder
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters
+import org.springframework.security.oauth2.jwt.JwtException
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+@Service
+class JwtService(
+    private val encoder: JwtEncoder,
+    private val decoder: JwtDecoder,
+    @Value("\${auth.jwt.token-lifetime}") private val tokenLifetime: Duration,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun mint(
+        email: String,
+        userId: UUID? = null,
+        tenantId: UUID? = null,
+    ): String {
+        val now = Instant.now()
+        val claims =
+            JwtClaimsSet
+                .builder()
+                // `sub` always holds email — the one identity attribute present on every
+                // token, whether the user record exists yet (post-invitation-acceptance)
+                // or not (stub-auth path). `userId` / `tenantId` are separate claims.
+                .subject(email)
+                .claim("email", email)
+                .apply {
+                    userId?.let { claim("userId", it.toString()) }
+                    tenantId?.let { claim("tenantId", it.toString()) }
+                }.issuedAt(now)
+                .expiresAt(now.plus(tokenLifetime))
+                .build()
+        val headers = JwsHeader.with(MacAlgorithm.HS256).build()
+        return encoder.encode(JwtEncoderParameters.from(headers, claims)).tokenValue
+    }
+
+    fun verify(token: String): Jwt? =
+        try {
+            decoder.decode(token)
+        } catch (e: JwtException) {
+            log.debug("JWT verification failed: {}", e.message)
+            null
+        }
+}

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/SecurityConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/SecurityConfig.kt
@@ -1,0 +1,54 @@
+package com.tcoverwatch.common.security
+
+import com.tcoverwatch.common.exception.PermissionDeniedException
+import com.tcoverwatch.common.exception.UnauthenticatedException
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Lazy
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.servlet.HandlerExceptionResolver
+
+@Configuration
+class SecurityConfig {
+    @Bean
+    fun securityFilterChain(
+        http: HttpSecurity,
+        jwtAuthFilter: JwtAuthenticationFilter,
+        // Delegate 401/403 from the security filter chain to Spring MVC's exception
+        // resolver, which routes through our @RestControllerAdvice. Same envelope
+        // shape regardless of whether the failure came from a controller or the
+        // security layer. @Lazy avoids the early-binding chicken-and-egg.
+        @Qualifier("handlerExceptionResolver") @Lazy exceptionResolver: HandlerExceptionResolver,
+    ): SecurityFilterChain {
+        http
+            // SPA + cookie auth on a same-parent-domain layout; SameSite=Lax + Origin
+            // checks are the defense. Revisit if a third-party form-post surface ever lands.
+            .csrf(AbstractHttpConfigurer<*, *>::disable)
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests {
+                it
+                    .requestMatchers(
+                        "/api/auth/**",
+                        "/api/ping",
+                        "/actuator/**",
+                        "/v3/api-docs/**",
+                        "/swagger-ui/**",
+                        "/swagger-ui.html",
+                    ).permitAll()
+                it.anyRequest().authenticated()
+            }.exceptionHandling { eh ->
+                eh.authenticationEntryPoint { req, res, _ ->
+                    exceptionResolver.resolveException(req, res, null, UnauthenticatedException("Sign in required"))
+                }
+                eh.accessDeniedHandler { req, res, _ ->
+                    exceptionResolver.resolveException(req, res, null, PermissionDeniedException("Forbidden"))
+                }
+            }.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
+        return http.build()
+    }
+}

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/SecurityConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/SecurityConfig.kt
@@ -19,15 +19,12 @@ class SecurityConfig {
     fun securityFilterChain(
         http: HttpSecurity,
         jwtAuthFilter: JwtAuthenticationFilter,
-        // Delegate 401/403 from the security filter chain to Spring MVC's exception
-        // resolver, which routes through our @RestControllerAdvice. Same envelope
-        // shape regardless of whether the failure came from a controller or the
-        // security layer. @Lazy avoids the early-binding chicken-and-egg.
+        // Routes 401/403 through ApiErrorAdvice so the envelope matches the controller path.
+        // @Lazy dodges the early-binding chicken-and-egg.
         @Qualifier("handlerExceptionResolver") @Lazy exceptionResolver: HandlerExceptionResolver,
     ): SecurityFilterChain {
         http
-            // SPA + cookie auth on a same-parent-domain layout; SameSite=Lax + Origin
-            // checks are the defense. Revisit if a third-party form-post surface ever lands.
+            // SameSite=Lax + same-parent-domain layout is the defense.
             .csrf(AbstractHttpConfigurer<*, *>::disable)
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/AuthController.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/AuthController.kt
@@ -3,13 +3,15 @@ package com.tcoverwatch.feature.auth.api
 import com.tcoverwatch.common.exception.UnauthenticatedException
 import com.tcoverwatch.common.security.AuthCookie
 import com.tcoverwatch.common.security.AuthenticatedPrincipal
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -19,16 +21,16 @@ class AuthController(
     private val authCookie: AuthCookie,
 ) {
     @GetMapping("/me")
+    @ResponseStatus(HttpStatus.OK)
     fun me(
         @AuthenticationPrincipal principal: AuthenticatedPrincipal?,
     ): MeResponse = principal?.toResponse() ?: throw UnauthenticatedException("Sign in required")
 
     @PostMapping("/logout")
-    fun logout(): ResponseEntity<Void> =
-        ResponseEntity
-            .noContent()
-            .header(HttpHeaders.SET_COOKIE, authCookie.clear())
-            .build()
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun logout(response: HttpServletResponse) {
+        response.addHeader(HttpHeaders.SET_COOKIE, authCookie.clear())
+    }
 }
 
 data class MeResponse(

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/AuthController.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/AuthController.kt
@@ -1,0 +1,40 @@
+package com.tcoverwatch.feature.auth.api
+
+import com.tcoverwatch.common.exception.UnauthenticatedException
+import com.tcoverwatch.common.security.AuthCookie
+import com.tcoverwatch.common.security.AuthenticatedPrincipal
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/auth", produces = [MediaType.APPLICATION_JSON_VALUE])
+class AuthController(
+    private val authCookie: AuthCookie,
+) {
+    @GetMapping("/me")
+    fun me(
+        @AuthenticationPrincipal principal: AuthenticatedPrincipal?,
+    ): MeResponse = principal?.toResponse() ?: throw UnauthenticatedException("Sign in required")
+
+    @PostMapping("/logout")
+    fun logout(): ResponseEntity<Void> =
+        ResponseEntity
+            .noContent()
+            .header(HttpHeaders.SET_COOKIE, authCookie.clear())
+            .build()
+}
+
+data class MeResponse(
+    val email: String,
+    val userId: UUID?,
+    val tenantId: UUID?,
+)
+
+internal fun AuthenticatedPrincipal.toResponse(): MeResponse = MeResponse(email = email, userId = userId, tenantId = tenantId)

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevAuthController.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevAuthController.kt
@@ -2,16 +2,18 @@ package com.tcoverwatch.feature.auth.api
 
 import com.tcoverwatch.common.security.AuthCookie
 import com.tcoverwatch.common.security.JwtService
+import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 // Profile-gated local-only stub: mints a JWT for any email a developer types,
@@ -26,14 +28,14 @@ class DevAuthController(
     private val authCookie: AuthCookie,
 ) {
     @PostMapping("/dev-login", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    @ResponseStatus(HttpStatus.OK)
     fun devLogin(
         @Valid @RequestBody request: DevLoginRequest,
-    ): ResponseEntity<MeResponse> {
+        response: HttpServletResponse,
+    ): MeResponse {
         val token = jwtService.mint(email = request.email)
-        return ResponseEntity
-            .ok()
-            .header(HttpHeaders.SET_COOKIE, authCookie.set(token))
-            .body(MeResponse(email = request.email, userId = null, tenantId = null))
+        response.addHeader(HttpHeaders.SET_COOKIE, authCookie.set(token))
+        return MeResponse(email = request.email, userId = null, tenantId = null)
     }
 }
 

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevAuthController.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevAuthController.kt
@@ -16,10 +16,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
-// Profile-gated local-only stub: mints a JWT for any email a developer types,
-// no invitation check, no Google. Wholly replaced by the real OAuth callback +
-// invitation gate in PR 3 of #18. NEVER reachable on unraid / prod — the
-// `@Profile("local")` annotation excludes the bean entirely from other profiles.
+// Dev-only stub — mints a JWT for any well-formed email, no invitation check.
+// @Profile("local") excludes the bean from every other profile.
 @RestController
 @RequestMapping("/api/auth", produces = [MediaType.APPLICATION_JSON_VALUE])
 @Profile("local")

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevAuthController.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevAuthController.kt
@@ -1,0 +1,44 @@
+package com.tcoverwatch.feature.auth.api
+
+import com.tcoverwatch.common.security.AuthCookie
+import com.tcoverwatch.common.security.JwtService
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import org.springframework.context.annotation.Profile
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+// Profile-gated local-only stub: mints a JWT for any email a developer types,
+// no invitation check, no Google. Wholly replaced by the real OAuth callback +
+// invitation gate in PR 3 of #18. NEVER reachable on unraid / prod — the
+// `@Profile("local")` annotation excludes the bean entirely from other profiles.
+@RestController
+@RequestMapping("/api/auth", produces = [MediaType.APPLICATION_JSON_VALUE])
+@Profile("local")
+class DevAuthController(
+    private val jwtService: JwtService,
+    private val authCookie: AuthCookie,
+) {
+    @PostMapping("/dev-login", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun devLogin(
+        @Valid @RequestBody request: DevLoginRequest,
+    ): ResponseEntity<MeResponse> {
+        val token = jwtService.mint(email = request.email)
+        return ResponseEntity
+            .ok()
+            .header(HttpHeaders.SET_COOKIE, authCookie.set(token))
+            .body(MeResponse(email = request.email, userId = null, tenantId = null))
+    }
+}
+
+data class DevLoginRequest(
+    @field:NotBlank
+    @field:Email
+    val email: String,
+)

--- a/server/src/main/kotlin/com/tcoverwatch/feature/ping/api/PingController.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/ping/api/PingController.kt
@@ -5,10 +5,12 @@ import com.tcoverwatch.feature.ping.service.PingService
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import java.time.Instant
 import java.util.UUID
@@ -19,6 +21,7 @@ class PingController(
     private val pingService: PingService,
 ) {
     @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
+    @ResponseStatus(HttpStatus.OK)
     fun ping(
         @Valid @RequestBody request: PingRequest,
     ): PingResponse = pingService.ping(request.toDto()).toResponse()

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -31,9 +31,7 @@ logging:
 
 auth:
   jwt:
-    # HS256 needs ≥32 bytes. This string is local-dev-only — replace via env in any
-    # non-local profile. NOT a secret in any meaningful sense.
+    # Local-dev only. HS256 needs ≥32 bytes; this string isn't a real secret.
     secret: "tc-overwatch-local-dev-jwt-secret-do-not-use-in-prod"
   cookie:
-    # Plain HTTP on localhost; HTTPS-only flag would block the cookie.
-    secure: false
+    secure: false  # Secure=true would block the cookie over plain HTTP

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -28,3 +28,12 @@ logging:
   level:
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql: TRACE
+
+auth:
+  jwt:
+    # HS256 needs ≥32 bytes. This string is local-dev-only — replace via env in any
+    # non-local profile. NOT a secret in any meaningful sense.
+    secret: "tc-overwatch-local-dev-jwt-secret-do-not-use-in-prod"
+  cookie:
+    # Plain HTTP on localhost; HTTPS-only flag would block the cookie.
+    secure: false

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -54,14 +54,11 @@ logging:
     root: INFO
     com.tcoverwatch: DEBUG
 
-# Authentication. v0 mints HS256 JWTs (stub login path); the wiring is reused
-# when real Google OAuth lands. Real auth-flow strategy in docs/architecture.md
-# § Authentication.
+# See docs/architecture.md § Authentication.
 auth:
   jwt:
-    # secret — required at startup. Set via env var AUTH_JWT_SECRET in unraid / prod
-    # (Secret Manager backed). Local has its own value in application-local.yml.
+    # Required. `auth.jwt.secret` comes from AUTH_JWT_SECRET (Secret Manager-backed
+    # in prod); application-local.yml has its own value.
     token-lifetime: 7d
   cookie:
-    # Safe prod default; local profile overrides for plain-HTTP dev.
-    secure: true
+    secure: true  # local profile flips to false for plain-HTTP localhost

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -53,3 +53,15 @@ logging:
   level:
     root: INFO
     com.tcoverwatch: DEBUG
+
+# Authentication. v0 mints HS256 JWTs (stub login path); the wiring is reused
+# when real Google OAuth lands. Real auth-flow strategy in docs/architecture.md
+# § Authentication.
+auth:
+  jwt:
+    # secret — required at startup. Set via env var AUTH_JWT_SECRET in unraid / prod
+    # (Secret Manager backed). Local has its own value in application-local.yml.
+    token-lifetime: 7d
+  cookie:
+    # Safe prod default; local profile overrides for plain-HTTP dev.
+    secure: true


### PR DESCRIPTION
Second PR in the access-control epic (#18). Stands up Spring Security 7, mints HS256 JWTs into a session cookie, wires a local-only stub login form so the auth flow can be exercised end-to-end without Google OAuth. The real OAuth callback + invitation gate replaces the stub in PR 3.

## Summary

- **Backend** — Spring Security `SecurityFilterChain` with stateless sessions + JWT filter (`com.tcoverwatch.common.security/`); `JwtService` mints + verifies HS256 tokens; `AuthCookie` centralizes the `tco_session` cookie shape; `AuthController` (`/api/auth/me` + `/api/auth/logout`) + `@Profile("local")` `DevAuthController` (`/api/auth/dev-login`).
- **Frontend** — `useMe()` / `useDevLogin()` / `useLogout()` hooks, `<DevLoginCard>` + `<UserBadge>` components, `App.tsx` gates the ping card behind auth state.
- **IntelliJ run configs** — `.run/postgres-up.run.xml` + `backend.run.xml` (with `beforeRun` Postgres dependency) + `frontend.run.xml` + `local-stack.run.xml` (compound). One-click full local stack.
- **Docs** — architecture.md § Authentication updated; new § Security in spring-boot.md.

Belongs to epic #18.

## Test plan

- [x] `./gradlew :server:build` clean
- [x] `npm --prefix frontend run build && run lint` clean
- [x] `gen-api-types` produces no drift
- [x] curl matrix: 401 / 200 / 204 / 400 across `/api/auth/me`, `/api/auth/dev-login`, `/api/auth/logout`, arbitrary unmatched path, plus `/api/ping` still public
- [x] Decoded JWT payload: `sub = email` consistently
- [x] Playwright/Chrome end-to-end: DevLoginCard → submit email → UserBadge + PingCard → Send Ping works → Sign out → DevLoginCard returns, cookie cleared
- [x] Cookie attributes verified: `HttpOnly`, `SameSite=Lax`, `Secure=false` (local profile), `Path=/`

## Notes

- **`spring-boot-starter-oauth2-resource-server`** is the only new dep — provides `JwtEncoder`/`JwtDecoder` beans. Same machinery handles real Google OAuth validation when that lands. The existing `spring-boot-starter-security` was already in the catalog from the scaffold.
- **CSRF disabled** for the SPA + cookie auth pattern; `SameSite=Lax` is the defense. Revisit at the hardening pass.
- **401/403 from the security filter chain delegate to `HandlerExceptionResolver` via `@Lazy`** so the existing `ApiErrorAdvice` produces the envelope. No duplicate JSON serialization in the security layer; envelopes match across controller-thrown and filter-thrown paths.
- **`DevAuthController` is `@Profile("local")`** — bean does not exist outside local. New convention pinned in `docs/claude/spring-boot.md`: profile-gated controllers go in their own file, never mixed with unconditional ones.
- **JWT `sub` claim is always `email`** (not userId-or-email) so callers reading `sub` get a stable type. `userId` / `tenantId` are separate claims, populated when known.

## Out of scope

- Auth gate + invitation acceptance flow → PR 3 of #18
- Tenant context propagation (request → `SET LOCAL app.tenant_id`) + invitation admin utility → PR 4 of #18
- Real Google OAuth callback → after PR 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)