### PR TITLE
Multi-tenancy: TenantBindingAspect + invitation admin endpoint

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,7 +86,7 @@ If a future service-to-service caller actually needs a typed RPC contract, revis
 
 ### Multi-tenancy in the request pipeline
 
-Single Postgres, every tenant-scoped table carries `tenant_id` (UUID, NOT NULL). **RLS is enforced from day one** — full details in *Multi-tenancy* section below. A `TenantContext` interceptor on every request derives the tenant from the authenticated session and sets `app.tenant_id` on the DB session via `SET LOCAL` at transaction start.
+Single Postgres, every tenant-scoped table carries `tenant_id` (UUID, NOT NULL). **RLS is enforced from day one** — full details in *Multi-tenancy* section below. `TenantBindingAspect` (Spring AOP, in `com.tcoverwatch.common.multitenancy`) wraps every `@Transactional` method, reads the authenticated principal's `tenantId` from `SecurityContextHolder`, and calls `set_config('app.tenant_id', …, true)` so RLS sees the right tenant. Pinned to fire INSIDE the transaction via `MultiTenancyConfig`'s `@EnableTransactionManagement(order = 0)` paired with `@Order(1)` on the aspect. Anonymous calls (`/api/auth/dev-login`, the local dev `POST /api/dev/invitations` seeder) hit the aspect, find no principal, no-op — the auth gate handles its own transaction-local binding before inserting `app_user`.
 
 ### Locked-in defaults
 
@@ -413,7 +413,7 @@ Developer runs `gradle bootRun` and `vite dev` from their laptop against a local
     USING (tenant_id = NULLIF(current_setting('app.tenant_id', true), '')::uuid);
   ```
   In practice migrations call `SELECT tco.enable_tenant_isolation('[table_name]')` — see `docs/claude/liquibase.md` § Tenant-scoped table template. `NULLIF` is required: `current_setting(.., true)` returns `''` (not NULL) when the setting is unset, and `''::uuid` throws.
-- The Spring Boot request pipeline sets `app.tenant_id` on the Postgres session at the start of each transaction, derived from the authenticated user. A small `@Component` `TenantConnectionInterceptor` (or equivalent JPA listener) executes `SET LOCAL app.tenant_id = '<uuid>'` on connection acquisition; the value is cleared at transaction end.
+- The Spring Boot request pipeline sets `app.tenant_id` on the Postgres session at the start of each transaction, derived from the authenticated user. `TenantBindingAspect` (a Spring AOP `@Around` advice on `@Transactional` methods) reads the principal's `tenantId` from `SecurityContextHolder` and calls `set_config('app.tenant_id', <uuid>, true)` — the `true` makes it transaction-LOCAL, released at commit/rollback. The aspect is ordered to fire INSIDE the transaction (advisor `order = 0`, aspect `@Order(1)`) so the binding sits between BEGIN and any query.
 - Migrations declare RLS policies alongside the tables they protect (Liquibase (Groovy DSL) migrations include both `CREATE TABLE` and `CREATE POLICY` in the same file).
 - Tests use Testcontainers Postgres with the same RLS policies enabled; a test must explicitly set the tenant context to read/write rows, which catches cross-tenant bugs at unit-test time.
 

--- a/docs/claude/kotlin.md
+++ b/docs/claude/kotlin.md
@@ -8,6 +8,10 @@ Kotlin 2.2.x, JDK 21+ (local toolchain 23 per scaffold), `-Xjsr305=strict`.
 
 ktlint + detekt enforced in CI: `./gradlew :server:ktlintCheck :server:detekt`; auto-fix with `:server:ktlintFormat`. Files end with a trailing newline. Gradle uses `compilerOptions { }` (Kotlin 2.x); older `kotlinOptions { }` is deprecated.
 
+## Comments
+
+**Default to no comments. When you do write one, keep it to 2 lines or less.** If it needs three lines, the code is the wrong shape — fix it, or lift the explanation to the relevant rule file in `docs/claude/`. Restating a project rule in a code comment is forbidden; the rule docs (`spring-boot.md`, `liquibase.md`, this file) are the source of truth. A comment earns its place only when the **why** is genuinely non-obvious — a hidden constraint, a workaround for a specific bug, an invariant a reader would otherwise miss. Don't explain what the code does; identifiers do that.
+
 ## Idioms
 
 - **Data classes** for DTOs. No setters; use `copy()` for derivation. Don't add behavior to data classes — keep them dumb.

--- a/docs/claude/react.md
+++ b/docs/claude/react.md
@@ -6,6 +6,10 @@ Installed (scaffold): React 19, TypeScript 5.7, Vite 6, ESLint 9 flat config.
 
 Pinned, install per-feature: **TanStack Query v5+** with hand-written typed `fetch` wrappers (no codegen, no proto), Mantine v8+ (`@mantine/core` + `@mantine/hooks`; sub-packages per-feature), React Router v6.4+ Data Router, react-hook-form + Zod (`@hookform/resolvers/zod`), Vitest + RTL + user-event + MSW for HTTP mocking in tests.
 
+## Comments
+
+**Default to no comments. When you do write one, keep it to 2 lines or less.** If a comment needs three lines, the code is the wrong shape — fix it, or lift the explanation to the rule docs. Don't restate project rules in code. A comment earns its place only when the **why** is genuinely non-obvious.
+
 ## TypeScript
 
 TypeScript only. No JS in `src/`. Strict mode stays on.

--- a/docs/claude/spring-boot.md
+++ b/docs/claude/spring-boot.md
@@ -6,7 +6,13 @@ Stack: Spring Boot 4 + Kotlin 2.2 + JDK 21+, plain HTTP/JSON via Spring MVC `@Re
 
 ## Layer boundaries
 
-Controller → Service → DAO → Repository → Database. Strategic detail in `architecture.md` § Layered architecture. Operational rule: a service or controller that imports an `*Entity` class is broken layering — entities never leave the DAO. (Kotlin `internal` can't enforce this with the current single-module layout; it's a review-time check.)
+Controller → Service → DAO → Repository → Database. Strategic detail in `architecture.md` § Layered architecture.
+
+**NON-NEGOTIABLE: a controller never touches a Hibernate entity.** Not as a parameter, not as a return type, not as a local, not as an import. Controllers consume **services** (which expose DTOs) and produce **response DTOs**. A controller that imports a `feature/*/persistence/*Entity` class is broken layering and must be fixed before merge.
+
+The same applies, with one degree less force, between services and entities: services may *hold* an entity locally inside a `@Transactional` method that orchestrates persistence (the auth gate does this), but **service public method signatures never use entities** — only service-layer DTOs. The boundary is the method signature.
+
+Kotlin `internal` can't enforce this with the current single-module layout; it's a review-time check. The check is binary — entity in a controller signature or import = block.
 
 ## Feature layout
 
@@ -194,7 +200,7 @@ Strategy + JWT shape pinned in `architecture.md` § Authentication / Security. O
 
 ## Anti-patterns
 
-- Returning entities from controllers or services.
+- **Controllers touching entities, period.** No parameter, return type, local, or import — see § Layer boundaries. Same prohibition with one less degree of force for service public method signatures.
 - Wrapping controller responses in `ResponseEntity` — return the DTO, use `@ResponseStatus` for the code and `HttpServletResponse` for header side effects.
 - Skipping a layer (controller → DAO, service → repository).
 - Manual `WHERE tenant_id = ?` filters — RLS does it.

--- a/docs/claude/spring-boot.md
+++ b/docs/claude/spring-boot.md
@@ -115,8 +115,11 @@ Thin. Derived query methods + `@Query` for one-off SQL. Complex queries → DAO.
 Strategy in `architecture.md` § Multi-tenancy. In code:
 
 - Never write `WHERE tenant_id = ?` — RLS filters automatically once `app.tenant_id` is set on the session.
-- Cross-tenant work goes through an explicit `withAdminConnection { ... }` block on the `tco_admin` pool. Grep-able, reviewable, rare.
-- Per-tenant background jobs `SET LOCAL app.tenant_id` before any DB work. A wrapper utility makes this automatic; forgetting it shows up as queries returning empty under RLS.
+- **`TenantBindingAspect` (in `com.tcoverwatch.common.multitenancy`) sets `app.tenant_id` automatically.** It fires INSIDE every `@Transactional` method (Spring's transactional advisor is pinned to `order = 0` in `MultiTenancyConfig`; the aspect is `@Order(1)`, so it wraps inside). Reads the current `SecurityContext`'s `AuthenticatedPrincipal.tenantId` and calls `set_config('app.tenant_id', tenantId, true)`. No principal → no-op (auth gate path still works).
+- **What this means for service code**: write `@Transactional` methods that do tenant-scoped queries normally — RLS handles tenant scoping invisibly. Don't manually call `set_config` unless you're inside a *cross-tenant* operation (the auth gate, system jobs).
+- **Cross-tenant lookups** (e.g., "is this email registered in any tenant?") route through a `SECURITY DEFINER` Postgres function — see `tco.find_app_user_by_email` in `fn-auth-lookups.sql`. Owned by `tco_migrate` (table owner), bypasses RLS, `search_path` locked to `tco, pg_temp`. Set this precedent for any future cross-tenant access.
+- **Pointcut limitation**: `@Transactional` declared on Spring Data repository methods (e.g., `JpaRepository.findById`) is matched only when the call goes through a Spring-managed service. Direct controller-to-repository calls bypass the aspect. Rule of thumb: controllers → services → repositories.
+- Per-tenant background jobs do their own `SET LOCAL app.tenant_id` before any DB work (no SecurityContext to read from). A small `withTenantContext(tenantId) { ... }` helper will land when the first background job does.
 
 ## Naming
 

--- a/frontend/src/gen/api.d.ts
+++ b/frontend/src/gen/api.d.ts
@@ -20,6 +20,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/dev/invitations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["createInvitation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/logout": {
         parameters: {
             query?: never;
@@ -46,6 +62,22 @@ export interface paths {
         get?: never;
         put?: never;
         post: operations["devLogin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/rls-probe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["rlsProbe"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -81,6 +113,19 @@ export interface components {
             /** Format: uuid */
             id?: string;
         };
+        CreateInvitationRequest: {
+            /** Format: email */
+            email: string;
+        };
+        InvitationResponse: {
+            /** Format: uuid */
+            id?: string;
+            email?: string;
+            /** Format: uuid */
+            token?: string;
+            /** Format: date-time */
+            createdAt?: string;
+        };
         DevLoginRequest: {
             /** Format: email */
             email: string;
@@ -95,6 +140,12 @@ export interface components {
             userId?: string | null;
             /** Format: uuid */
             tenantId?: string | null;
+        };
+        RlsProbeResponse: {
+            tenantBound?: boolean;
+            email?: string | null;
+            /** Format: uuid */
+            userId?: string | null;
         };
     };
     responses: never;
@@ -125,6 +176,30 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PingResponse"];
+                };
+            };
+        };
+    };
+    createInvitation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateInvitationRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InvitationResponse"];
                 };
             };
         };
@@ -167,6 +242,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LoginResponse"];
+                };
+            };
+        };
+    };
+    rlsProbe: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RlsProbeResponse"];
                 };
             };
         };

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ assertk                 = "0.28.1"
 detekt                  = "1.23.8"
 ktlintPlugin            = "12.1.2"
 springdocOpenapi        = "3.0.3"
-aspectjweaver           = "1.9.9.1"
+aspectjweaver           = "1.9.22.1"
 
 [libraries]
 # Spring Boot BOM (pulls in Spring web, security, data-jpa, actuator, etc. via dependency-management plugin)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ assertk                 = "0.28.1"
 detekt                  = "1.23.8"
 ktlintPlugin            = "12.1.2"
 springdocOpenapi        = "3.0.3"
+aspectjweaver           = "1.9.9.1"
 
 [libraries]
 # Spring Boot BOM (pulls in Spring web, security, data-jpa, actuator, etc. via dependency-management plugin)
@@ -24,6 +25,11 @@ springBoot-starter-data-jpa         = { module = "org.springframework.boot:sprin
 springBoot-starter-actuator         = { module = "org.springframework.boot:spring-boot-starter-actuator" }
 springBoot-starter-validation       = { module = "org.springframework.boot:spring-boot-starter-validation" }
 springBoot-starter-oauth2-resource-server = { module = "org.springframework.boot:spring-boot-starter-oauth2-resource-server" }
+
+# Spring Boot 4 dropped spring-boot-starter-aop; pull aspectjweaver directly.
+# spring-aop comes in transitively via other starters. @EnableAspectJAutoProxy
+# is auto-configured when aspectjweaver is on the classpath.
+aspectjweaver                       = { module = "org.aspectj:aspectjweaver", version.ref = "aspectjweaver" }
 springBoot-starter-test             = { module = "org.springframework.boot:spring-boot-starter-test" }
 
 # OpenAPI / Swagger UI — walks @RestControllers, Jackson + Bean Validation annotations,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,9 +26,7 @@ springBoot-starter-actuator         = { module = "org.springframework.boot:sprin
 springBoot-starter-validation       = { module = "org.springframework.boot:spring-boot-starter-validation" }
 springBoot-starter-oauth2-resource-server = { module = "org.springframework.boot:spring-boot-starter-oauth2-resource-server" }
 
-# Spring Boot 4 dropped spring-boot-starter-aop; pull aspectjweaver directly.
-# spring-aop comes in transitively via other starters. @EnableAspectJAutoProxy
-# is auto-configured when aspectjweaver is on the classpath.
+# Spring Boot 4 dropped spring-boot-starter-aop — pull aspectjweaver directly (spring-aop comes via other starters).
 aspectjweaver                       = { module = "org.aspectj:aspectjweaver", version.ref = "aspectjweaver" }
 springBoot-starter-test             = { module = "org.springframework.boot:spring-boot-starter-test" }
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -42,6 +42,10 @@ dependencies {
     // JWT encoder/decoder beans. Pulled in for the stub auth path; the same module
     // covers Google OAuth resource-server validation when real OAuth lands.
     implementation(libs.springBoot.starter.oauth2.resource.server)
+    // AOP — TenantBindingAspect binds app.tenant_id inside @Transactional methods.
+    // Spring Boot 4 dropped its AOP starter; aspectjweaver direct + spring-aop
+    // transitive (via security/data-jpa) is the equivalent.
+    implementation(libs.aspectjweaver)
 
     // OpenAPI 3 spec + Swagger UI. Auto-walks @RestControllers — no annotations required
     // on existing code. See docs/claude/spring-boot.md § OpenAPI for the field-doc convention.

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -42,9 +42,7 @@ dependencies {
     // JWT encoder/decoder beans. Pulled in for the stub auth path; the same module
     // covers Google OAuth resource-server validation when real OAuth lands.
     implementation(libs.springBoot.starter.oauth2.resource.server)
-    // AOP — TenantBindingAspect binds app.tenant_id inside @Transactional methods.
-    // Spring Boot 4 dropped its AOP starter; aspectjweaver direct + spring-aop
-    // transitive (via security/data-jpa) is the equivalent.
+    // AOP for TenantBindingAspect. SB4 dropped starter-aop; aspectjweaver + transitive spring-aop is the equivalent.
     implementation(libs.aspectjweaver)
 
     // OpenAPI 3 spec + Swagger UI. Auto-walks @RestControllers — no annotations required

--- a/server/src/main/kotlin/com/tcoverwatch/common/multitenancy/MultiTenancyConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/multitenancy/MultiTenancyConfig.kt
@@ -1,0 +1,12 @@
+package com.tcoverwatch.common.multitenancy
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.transaction.annotation.EnableTransactionManagement
+
+// Pin the @Transactional advisor's order to 0 so TenantBindingAspect (@Order(1))
+// can fire INSIDE the transaction Spring opens. Default order is
+// Ordered.LOWEST_PRECEDENCE, which would put any other aspect outside the tx
+// and break the set_config(.., true) lifecycle.
+@Configuration
+@EnableTransactionManagement(order = 0)
+class MultiTenancyConfig

--- a/server/src/main/kotlin/com/tcoverwatch/common/multitenancy/MultiTenancyConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/multitenancy/MultiTenancyConfig.kt
@@ -3,10 +3,9 @@ package com.tcoverwatch.common.multitenancy
 import org.springframework.context.annotation.Configuration
 import org.springframework.transaction.annotation.EnableTransactionManagement
 
-// Pin the @Transactional advisor's order to 0 so TenantBindingAspect (@Order(1))
-// can fire INSIDE the transaction Spring opens. Default order is
-// Ordered.LOWEST_PRECEDENCE, which would put any other aspect outside the tx
-// and break the set_config(.., true) lifecycle.
+// Pin the @Transactional advisor to order=0 so TenantBindingAspect (@Order(1))
+// runs INSIDE the transaction. Default LOWEST_PRECEDENCE would put the aspect
+// outside the tx, breaking set_config(.., true)'s tx-LOCAL lifecycle.
 @Configuration
 @EnableTransactionManagement(order = 0)
 class MultiTenancyConfig

--- a/server/src/main/kotlin/com/tcoverwatch/common/multitenancy/MultiTenancyConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/multitenancy/MultiTenancyConfig.kt
@@ -3,9 +3,7 @@ package com.tcoverwatch.common.multitenancy
 import org.springframework.context.annotation.Configuration
 import org.springframework.transaction.annotation.EnableTransactionManagement
 
-// Pin the @Transactional advisor to order=0 so TenantBindingAspect (@Order(1))
-// runs INSIDE the transaction. Default LOWEST_PRECEDENCE would put the aspect
-// outside the tx, breaking set_config(.., true)'s tx-LOCAL lifecycle.
+// Advisor order=0 pairs with TenantBindingAspect @Order(1) so the aspect runs INSIDE the tx.
 @Configuration
 @EnableTransactionManagement(order = 0)
 class MultiTenancyConfig

--- a/server/src/main/kotlin/com/tcoverwatch/common/multitenancy/TenantBindingAspect.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/multitenancy/TenantBindingAspect.kt
@@ -1,0 +1,50 @@
+package com.tcoverwatch.common.multitenancy
+
+import com.tcoverwatch.common.security.AuthenticatedPrincipal
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.core.annotation.Order
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+
+// Binds app.tenant_id on the Postgres connection for the duration of every
+// @Transactional method invoked by an authenticated request, so RLS filters
+// tenant-scoped tables automatically.
+//
+// Ordering: TransactionConfig pins @EnableTransactionManagement(order = 0) and
+// this aspect is @Order(1), so we run INSIDE the transaction Spring opened —
+// the set_config(.., true) lives for that one tx and is released at commit.
+//
+// No principal in SecurityContext → no-op. That's the path the auth gate
+// (AuthService.signIn) takes — it sets app.tenant_id itself once it knows
+// the tenant, and uses SECURITY DEFINER for the pre-tenant lookup.
+@Aspect
+@Component
+@Order(1)
+class TenantBindingAspect(
+    @PersistenceContext private val entityManager: EntityManager,
+) {
+    @Around(
+        "@annotation(org.springframework.transaction.annotation.Transactional) || " +
+            "@within(org.springframework.transaction.annotation.Transactional)",
+    )
+    fun bindTenant(joinPoint: ProceedingJoinPoint): Any? {
+        val tenantId =
+            SecurityContextHolder
+                .getContext()
+                .authentication
+                ?.principal
+                ?.let { it as? AuthenticatedPrincipal }
+                ?.tenantId
+        if (tenantId != null) {
+            entityManager
+                .createNativeQuery("SELECT set_config('app.tenant_id', :tenantId, true)")
+                .setParameter("tenantId", tenantId.toString())
+                .singleResult
+        }
+        return joinPoint.proceed()
+    }
+}

--- a/server/src/main/kotlin/com/tcoverwatch/common/multitenancy/TenantBindingAspect.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/multitenancy/TenantBindingAspect.kt
@@ -10,17 +10,11 @@ import org.springframework.core.annotation.Order
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 
-// Binds app.tenant_id on the Postgres connection for the duration of every
-// @Transactional method invoked by an authenticated request, so RLS filters
-// tenant-scoped tables automatically.
-//
-// Ordering: TransactionConfig pins @EnableTransactionManagement(order = 0) and
-// this aspect is @Order(1), so we run INSIDE the transaction Spring opened —
-// the set_config(.., true) lives for that one tx and is released at commit.
-//
-// No principal in SecurityContext → no-op. That's the path the auth gate
-// (AuthService.signIn) takes — it sets app.tenant_id itself once it knows
-// the tenant, and uses SECURITY DEFINER for the pre-tenant lookup.
+// Binds app.tenant_id inside every @Transactional method invoked by an
+// authenticated request, so RLS filters tenant-scoped tables automatically.
+// Order(1) + advisor pinned to order=0 in MultiTenancyConfig → we run INSIDE
+// the transaction; set_config(.., true) is released at commit.
+// No principal → no-op (the auth gate handles its own pre-tenant binding).
 @Aspect
 @Component
 @Order(1)

--- a/server/src/main/kotlin/com/tcoverwatch/common/multitenancy/TenantBindingAspect.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/multitenancy/TenantBindingAspect.kt
@@ -10,11 +10,7 @@ import org.springframework.core.annotation.Order
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 
-// Binds app.tenant_id inside every @Transactional method invoked by an
-// authenticated request, so RLS filters tenant-scoped tables automatically.
-// Order(1) + advisor pinned to order=0 in MultiTenancyConfig → we run INSIDE
-// the transaction; set_config(.., true) is released at commit.
-// No principal → no-op (the auth gate handles its own pre-tenant binding).
+// Mechanism + ordering pairing with MultiTenancyConfig in docs/claude/spring-boot.md § Multi-tenancy / RLS.
 @Aspect
 @Component
 @Order(1)

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/SecurityConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/SecurityConfig.kt
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
-import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -38,11 +37,6 @@ class SecurityConfig {
                         "/swagger-ui/**",
                         "/swagger-ui.html",
                     ).permitAll()
-                // POST /api/dev/invitations is the local-only invitation-seeding path
-                // (DevAdminController, @Profile("local")). Anonymous in local; bean
-                // doesn't exist in other profiles so the matcher matches nothing.
-                it.requestMatchers(HttpMethod.POST, "/api/dev/invitations").permitAll()
-                // Other /api/dev/* endpoints (e.g., the RLS probe) require auth.
                 it.anyRequest().authenticated()
             }.exceptionHandling { eh ->
                 eh.authenticationEntryPoint { req, res, _ ->

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/SecurityConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/SecurityConfig.kt
@@ -19,8 +19,7 @@ class SecurityConfig {
     fun securityFilterChain(
         http: HttpSecurity,
         jwtAuthFilter: JwtAuthenticationFilter,
-        // Routes 401/403 through ApiErrorAdvice so the envelope matches the controller path.
-        // @Lazy dodges the early-binding chicken-and-egg.
+        // Routes 401/403 through ApiErrorAdvice for envelope parity; @Lazy dodges early-binding.
         @Qualifier("handlerExceptionResolver") @Lazy exceptionResolver: HandlerExceptionResolver,
     ): SecurityFilterChain {
         http

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/SecurityConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/SecurityConfig.kt
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -37,6 +38,11 @@ class SecurityConfig {
                         "/swagger-ui/**",
                         "/swagger-ui.html",
                     ).permitAll()
+                // POST /api/dev/invitations is the local-only invitation-seeding path
+                // (DevAdminController, @Profile("local")). Anonymous in local; bean
+                // doesn't exist in other profiles so the matcher matches nothing.
+                it.requestMatchers(HttpMethod.POST, "/api/dev/invitations").permitAll()
+                // Other /api/dev/* endpoints (e.g., the RLS probe) require auth.
                 it.anyRequest().authenticated()
             }.exceptionHandling { eh ->
                 eh.authenticationEntryPoint { req, res, _ ->

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/AuthContracts.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/AuthContracts.kt
@@ -2,6 +2,7 @@ package com.tcoverwatch.feature.auth.api
 
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
+import java.time.Instant
 import java.util.UUID
 
 data class MeResponse(
@@ -19,4 +20,23 @@ data class DevLoginRequest(
     @field:NotBlank
     @field:Email
     val email: String,
+)
+
+data class CreateInvitationRequest(
+    @field:NotBlank
+    @field:Email
+    val email: String,
+)
+
+data class InvitationResponse(
+    val id: UUID,
+    val email: String,
+    val token: UUID,
+    val createdAt: Instant,
+)
+
+data class RlsProbeResponse(
+    val tenantBound: Boolean,
+    val email: String?,
+    val userId: UUID?,
 )

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevAdminController.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevAdminController.kt
@@ -1,10 +1,8 @@
 package com.tcoverwatch.feature.auth.api
 
-import com.tcoverwatch.common.exception.UnauthenticatedException
 import com.tcoverwatch.common.security.AuthenticatedPrincipal
-import com.tcoverwatch.feature.auth.persistence.Invitation
-import com.tcoverwatch.feature.auth.persistence.InvitationRepository
 import com.tcoverwatch.feature.auth.service.AuthService
+import com.tcoverwatch.feature.auth.service.InvitationDto
 import jakarta.validation.Valid
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpStatus
@@ -17,39 +15,28 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
-// Dev scaffolding endpoints. Profile-gated to local — never reachable on
-// unraid / prod. Used to seed invitations for local sign-in testing (closes
-// #42's "minimal admin RPC" path) and to probe the TenantBindingAspect.
+// Dev scaffolding: seed invitations for local sign-in testing + probe
+// TenantBindingAspect end-to-end. Lives in its own file because @Profile-gated
+// controllers don't share a file with unconditional ones.
 @RestController
 @RequestMapping("/api/dev", produces = [MediaType.APPLICATION_JSON_VALUE])
 @Profile("local")
 class DevAdminController(
-    private val invitationRepository: InvitationRepository,
     private val authService: AuthService,
 ) {
     @PostMapping("/invitations", consumes = [MediaType.APPLICATION_JSON_VALUE])
     @ResponseStatus(HttpStatus.CREATED)
     fun createInvitation(
         @Valid @RequestBody request: CreateInvitationRequest,
-    ): InvitationResponse {
-        val saved = invitationRepository.save(Invitation(email = request.email.lowercase()))
-        return InvitationResponse(
-            id = requireNotNull(saved.id),
-            email = saved.email,
-            token = requireNotNull(saved.token) { "token populated by DB default" },
-            createdAt = requireNotNull(saved.createdAt) { "createdAt populated by DB default" },
-        )
-    }
+    ): InvitationResponse = authService.createInvitation(request.email).toResponse()
 
-    // Exercises TenantBindingAspect. Does an RLS-scoped lookup for the
-    // authenticated principal's own app_user row. Without the aspect setting
-    // app.tenant_id, RLS hides the row → `tenantBound: false`.
+    // Without TenantBindingAspect setting app.tenant_id, RLS hides the row → tenantBound: false.
     @GetMapping("/rls-probe")
     @ResponseStatus(HttpStatus.OK)
     fun rlsProbe(
-        @AuthenticationPrincipal principal: AuthenticatedPrincipal?,
+        @AuthenticationPrincipal principal: AuthenticatedPrincipal,
     ): RlsProbeResponse {
-        val userId = principal?.userId ?: throw UnauthenticatedException("Sign in required")
+        val userId = requireNotNull(principal.userId) { "principal userId missing — token was issued without it" }
         val user = authService.findCurrentAppUser(userId)
         return RlsProbeResponse(
             tenantBound = user != null,
@@ -58,3 +45,6 @@ class DevAdminController(
         )
     }
 }
+
+internal fun InvitationDto.toResponse(): InvitationResponse =
+    InvitationResponse(id = id, email = email, token = token, createdAt = createdAt)

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevAdminController.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevAdminController.kt
@@ -1,0 +1,60 @@
+package com.tcoverwatch.feature.auth.api
+
+import com.tcoverwatch.common.exception.UnauthenticatedException
+import com.tcoverwatch.common.security.AuthenticatedPrincipal
+import com.tcoverwatch.feature.auth.persistence.Invitation
+import com.tcoverwatch.feature.auth.persistence.InvitationRepository
+import com.tcoverwatch.feature.auth.service.AuthService
+import jakarta.validation.Valid
+import org.springframework.context.annotation.Profile
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+// Dev scaffolding endpoints. Profile-gated to local — never reachable on
+// unraid / prod. Used to seed invitations for local sign-in testing (closes
+// #42's "minimal admin RPC" path) and to probe the TenantBindingAspect.
+@RestController
+@RequestMapping("/api/dev", produces = [MediaType.APPLICATION_JSON_VALUE])
+@Profile("local")
+class DevAdminController(
+    private val invitationRepository: InvitationRepository,
+    private val authService: AuthService,
+) {
+    @PostMapping("/invitations", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createInvitation(
+        @Valid @RequestBody request: CreateInvitationRequest,
+    ): InvitationResponse {
+        val saved = invitationRepository.save(Invitation(email = request.email.lowercase()))
+        return InvitationResponse(
+            id = requireNotNull(saved.id),
+            email = saved.email,
+            token = requireNotNull(saved.token) { "token populated by DB default" },
+            createdAt = requireNotNull(saved.createdAt) { "createdAt populated by DB default" },
+        )
+    }
+
+    // Exercises TenantBindingAspect. Does an RLS-scoped lookup for the
+    // authenticated principal's own app_user row. Without the aspect setting
+    // app.tenant_id, RLS hides the row → `tenantBound: false`.
+    @GetMapping("/rls-probe")
+    @ResponseStatus(HttpStatus.OK)
+    fun rlsProbe(
+        @AuthenticationPrincipal principal: AuthenticatedPrincipal?,
+    ): RlsProbeResponse {
+        val userId = principal?.userId ?: throw UnauthenticatedException("Sign in required")
+        val user = authService.findCurrentAppUser(userId)
+        return RlsProbeResponse(
+            tenantBound = user != null,
+            email = user?.email,
+            userId = user?.id,
+        )
+    }
+}

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevAdminController.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevAdminController.kt
@@ -15,9 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
-// Dev scaffolding: seed invitations for local sign-in testing + probe
-// TenantBindingAspect end-to-end. Lives in its own file because @Profile-gated
-// controllers don't share a file with unconditional ones.
 @RestController
 @RequestMapping("/api/dev", produces = [MediaType.APPLICATION_JSON_VALUE])
 @Profile("local")

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevSecurityConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevSecurityConfig.kt
@@ -1,0 +1,31 @@
+package com.tcoverwatch.feature.auth.api
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpMethod
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+
+// Profile-gated filter chain for the local-only dev seed endpoint. Kept here
+// (next to the controller) and @Profile("local") so the matcher itself doesn't
+// exist outside local — a future drop of @Profile on DevAdminController can't
+// expose POST /api/dev/invitations anonymously in prod.
+@Configuration
+@Profile("local")
+class DevSecurityConfig {
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    fun devSeedSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .securityMatchers { it.requestMatchers(HttpMethod.POST, "/api/dev/invitations") }
+            .csrf(AbstractHttpConfigurer<*, *>::disable)
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { it.anyRequest().permitAll() }
+        return http.build()
+    }
+}

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevSecurityConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/DevSecurityConfig.kt
@@ -11,10 +11,8 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 
-// Profile-gated filter chain for the local-only dev seed endpoint. Kept here
-// (next to the controller) and @Profile("local") so the matcher itself doesn't
-// exist outside local — a future drop of @Profile on DevAdminController can't
-// expose POST /api/dev/invitations anonymously in prod.
+// @Profile-gated so the permitAll matcher itself doesn't exist outside local —
+// a future drop of @Profile on DevAdminController can't expose the path in prod.
 @Configuration
 @Profile("local")
 class DevSecurityConfig {

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/service/AppUserDto.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/service/AppUserDto.kt
@@ -1,0 +1,9 @@
+package com.tcoverwatch.feature.auth.service
+
+import java.util.UUID
+
+data class AppUserDto(
+    val id: UUID,
+    val email: String,
+    val tenantId: UUID,
+)

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/service/AuthService.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/service/AuthService.kt
@@ -74,6 +74,12 @@ class AuthService(
         return user.toSignInResult()
     }
 
+    // Tenant-scoped lookup of the current principal's user row — exists primarily
+    // to exercise TenantBindingAspect end-to-end via the dev probe endpoint, but
+    // is the right shape for any future "refresh me from DB" flow too.
+    @Transactional(readOnly = true)
+    fun findCurrentAppUser(userId: java.util.UUID): AppUser? = appUserRepository.findById(userId).orElse(null)
+
     private fun AppUser.toSignInResult(): SignInResult {
         val userId = requireNotNull(id) { "AppUser must have an id after save" }
         return SignInResult(

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/service/AuthService.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/service/AuthService.kt
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.util.UUID
 
 @Service
 class AuthService(
@@ -30,6 +31,14 @@ class AuthService(
         // Normalize at the boundary — DB CHECK constraints enforce lowercase storage,
         // and case-insensitive sign-in is the universal user expectation.
         val normalizedEmail = email.lowercase()
+        // Advisory lock on the email serializes concurrent first sign-ins so two
+        // races don't both provision separate tenants (the unique constraint would
+        // catch the user INSERT but a half-built tenant row would remain). Released
+        // at transaction end. hashtext collisions block unrelated emails for ms — fine.
+        entityManager
+            .createNativeQuery("SELECT pg_advisory_xact_lock(hashtext(:email))")
+            .setParameter("email", normalizedEmail)
+            .singleResult
         // Returning user: cross-tenant lookup (no tenant context yet pre-auth);
         // RLS-scoped findByEmail would hide them.
         appUserRepository.findByEmailCrossTenant(normalizedEmail)?.let { existing ->
@@ -41,6 +50,12 @@ class AuthService(
             SignupMode.PAID -> throw FailedPreconditionException("Paid sign-up is not yet implemented")
         }
     }
+
+    @Transactional
+    fun createInvitation(email: String): InvitationDto = invitationRepository.save(Invitation(email = email.lowercase())).toDto()
+
+    @Transactional(readOnly = true)
+    fun findCurrentAppUser(userId: UUID): AppUserDto? = appUserRepository.findById(userId).orElse(null)?.toDto()
 
     private fun acceptInvitationOrReject(email: String): SignInResult {
         val invitation =
@@ -55,30 +70,22 @@ class AuthService(
     ): SignInResult {
         val tenant = tenantRepository.save(Tenant())
         val tenantId = requireNotNull(tenant.id) { "tenant id missing after save() — @GeneratedValue should populate it" }
-        // Bind app.tenant_id for the rest of this transaction so RLS's WITH CHECK
-        // accepts the app_user INSERT. set_config(.., true) is transaction-scoped —
-        // released at commit/rollback. Hibernate auto-flushes the queued tenant
-        // INSERT before this native query runs, so the tenant row exists by the
-        // time the config is set, and the config remains in effect through commit
-        // when the user INSERT actually fires.
+        // Flush so the tenant row exists when set_config runs and when the
+        // app_user FK fires at INSERT — don't depend on FlushMode.AUTO.
+        entityManager.flush()
+        // Pre-auth path has no principal, so TenantBindingAspect can't bind for us —
+        // do it ourselves so RLS WITH CHECK accepts the app_user INSERT.
         entityManager
             .createNativeQuery("SELECT set_config('app.tenant_id', :tenantId, true)")
             .setParameter("tenantId", tenantId.toString())
             .singleResult
         val user = appUserRepository.save(AppUser(tenantId = tenantId, email = email))
-        // JPA dirty-checking writes these field changes at commit — no explicit save() needed.
         fromInvitation?.also {
             it.acceptedAt = Instant.now()
             it.tenantId = tenantId
         }
         return user.toSignInResult()
     }
-
-    // Tenant-scoped lookup of the current principal's user row — exists primarily
-    // to exercise TenantBindingAspect end-to-end via the dev probe endpoint, but
-    // is the right shape for any future "refresh me from DB" flow too.
-    @Transactional(readOnly = true)
-    fun findCurrentAppUser(userId: java.util.UUID): AppUser? = appUserRepository.findById(userId).orElse(null)
 
     private fun AppUser.toSignInResult(): SignInResult {
         val userId = requireNotNull(id) { "AppUser must have an id after save" }
@@ -89,4 +96,19 @@ class AuthService(
             tenantId = tenantId,
         )
     }
+
+    private fun AppUser.toDto(): AppUserDto =
+        AppUserDto(
+            id = requireNotNull(id) { "AppUser must have an id" },
+            email = email,
+            tenantId = tenantId,
+        )
+
+    private fun Invitation.toDto(): InvitationDto =
+        InvitationDto(
+            id = requireNotNull(id) { "id missing after save() — @GeneratedValue should populate it" },
+            email = email,
+            token = token,
+            createdAt = requireNotNull(createdAt) { "createdAt missing after save() — @CreatedDate auditing should populate it" },
+        )
 }

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/service/AuthService.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/service/AuthService.kt
@@ -28,19 +28,15 @@ class AuthService(
 ) {
     @Transactional
     fun signIn(email: String): SignInResult {
-        // Normalize at the boundary — DB CHECK constraints enforce lowercase storage,
-        // and case-insensitive sign-in is the universal user expectation.
+        // Normalize at the boundary — DB CHECK enforces lowercase; sign-in is case-insensitive.
         val normalizedEmail = email.lowercase()
-        // Advisory lock on the email serializes concurrent first sign-ins so two
-        // races don't both provision separate tenants (the unique constraint would
-        // catch the user INSERT but a half-built tenant row would remain). Released
-        // at transaction end. hashtext collisions block unrelated emails for ms — fine.
+        // Serialize concurrent first sign-ins; otherwise two races both provision
+        // tenants before uq_app_user_email catches the user INSERT, leaving an orphan.
         entityManager
             .createNativeQuery("SELECT pg_advisory_xact_lock(hashtext(:email))")
             .setParameter("email", normalizedEmail)
             .singleResult
-        // Returning user: cross-tenant lookup (no tenant context yet pre-auth);
-        // RLS-scoped findByEmail would hide them.
+        // Cross-tenant lookup: no tenant context yet pre-auth; RLS-scoped findByEmail would hide.
         appUserRepository.findByEmailCrossTenant(normalizedEmail)?.let { existing ->
             return existing.toSignInResult()
         }
@@ -70,11 +66,9 @@ class AuthService(
     ): SignInResult {
         val tenant = tenantRepository.save(Tenant())
         val tenantId = requireNotNull(tenant.id) { "tenant id missing after save() — @GeneratedValue should populate it" }
-        // Flush so the tenant row exists when set_config runs and when the
-        // app_user FK fires at INSERT — don't depend on FlushMode.AUTO.
+        // Flush so subsequent ops see the tenant — don't rely on FlushMode.AUTO.
         entityManager.flush()
-        // Pre-auth path has no principal, so TenantBindingAspect can't bind for us —
-        // do it ourselves so RLS WITH CHECK accepts the app_user INSERT.
+        // Pre-auth: no principal yet, so bind app.tenant_id ourselves for the app_user RLS WITH CHECK.
         entityManager
             .createNativeQuery("SELECT set_config('app.tenant_id', :tenantId, true)")
             .setParameter("tenantId", tenantId.toString())

--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/service/InvitationDto.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/service/InvitationDto.kt
@@ -1,0 +1,11 @@
+package com.tcoverwatch.feature.auth.service
+
+import java.time.Instant
+import java.util.UUID
+
+data class InvitationDto(
+    val id: UUID,
+    val email: String,
+    val token: UUID,
+    val createdAt: Instant,
+)


### PR DESCRIPTION
## Summary

- `TenantBindingAspect` — Spring AOP `@Around` on `@Transactional` reads the authenticated principal's `tenantId` from `SecurityContextHolder` and calls `set_config('app.tenant_id', …, true)`. Pinned INSIDE the transaction via `MultiTenancyConfig`'s `@EnableTransactionManagement(order = 0)` + aspect `@Order(1)`. Anonymous calls no-op (auth gate continues to handle its own pre-INSERT binding).
- `DevAdminController` (`@Profile("local")`) — `POST /api/dev/invitations` (the minimal admin path for #42) and `GET /api/dev/rls-probe` (exercises the aspect end-to-end).
- Probe routes through new `AuthService.findCurrentAppUser` — the pointcut doesn't catch JDK-proxied Spring Data repo method invocations directly, so going through a Spring-managed service method is the right shape.
- Docs: `architecture.md` § Multi-tenancy + `claude/spring-boot.md` § Multi-tenancy / RLS updated to match (mechanism, ordering pin, cross-tenant SECURITY DEFINER precedent, pointcut limitation).

Closes #42.

## Test plan

- [x] `./gradlew :server:build` green
- [x] Seed invitation via `POST /api/dev/invitations` → 201 + invitation JSON
- [x] Sign in via `POST /api/auth/dev-login` → 200 + bearer token
- [x] `GET /api/dev/rls-probe` with bearer → `tenantBound: true`, principal's email + userId echoed back (RLS-scoped `findById` returned the row)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)