### PR TITLE
Unraid pilot stack: Postgres slice

### DIFF
--- a/.env.unraid.example
+++ b/.env.unraid.example
@@ -1,0 +1,16 @@
+# Schema for the Unraid pilot's .env file. The real file lives outside the repo
+# at /mnt/user/appdata/tco/.env with mode 0600 — never check it in.
+#
+# Generate strong random passwords:
+#   openssl rand -base64 32
+
+# --- Postgres (used by the postgres container) ---------------------------------
+POSTGRES_DB=tco
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=
+
+# --- Application role passwords (consumed by scripts/db-init-unraid/01-roles.sh
+#     at first DB init, and later by the backend via Spring config) -------------
+TCO_APP_PASSWORD=
+TCO_ADMIN_PASSWORD=
+TCO_MIGRATE_PASSWORD=

--- a/.env.unraid.example
+++ b/.env.unraid.example
@@ -1,5 +1,5 @@
 # Schema for the Unraid pilot's .env file. The real file lives outside the repo
-# at /mnt/user/appdata/tco/.env with mode 0600 — never check it in.
+# at /mnt/user/tco/.env with mode 0600 — never check it in.
 #
 # Generate strong random passwords:
 #   openssl rand -base64 32

--- a/docker-compose.unraid.yml
+++ b/docker-compose.unraid.yml
@@ -2,7 +2,7 @@
 #
 #   docker compose -f docker-compose.unraid.yml up -d
 #
-# Secrets come from /mnt/user/appdata/tco/.env (mode 0600, outside the repo).
+# Secrets come from /mnt/user/tco/.env (mode 0600, outside the repo).
 # See .env.unraid.example for the required keys.
 #
 # Backend, migrate, frontend, and cloudflared services land in later commits
@@ -14,9 +14,9 @@ services:
     container_name: tco-postgres
     restart: unless-stopped
     env_file:
-      - /mnt/user/appdata/tco/.env
+      - /mnt/user/tco/.env
     volumes:
-      - /mnt/user/appdata/tco/postgres:/var/lib/postgresql
+      - /mnt/user/tco/postgres:/var/lib/postgresql
       - ./scripts/db-init-unraid:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]

--- a/docker-compose.unraid.yml
+++ b/docker-compose.unraid.yml
@@ -1,0 +1,31 @@
+# Unraid pilot stack. Bring up via:
+#
+#   docker compose -f docker-compose.unraid.yml up -d
+#
+# Secrets come from /mnt/user/appdata/tco/.env (mode 0600, outside the repo).
+# See .env.unraid.example for the required keys.
+#
+# Backend, migrate, frontend, and cloudflared services land in later commits
+# on this branch.
+
+services:
+  postgres:
+    image: postgres:18
+    container_name: tco-postgres
+    restart: unless-stopped
+    env_file:
+      - /mnt/user/appdata/tco/.env
+    volumes:
+      - /mnt/user/appdata/tco/postgres:/var/lib/postgresql
+      - ./scripts/db-init-unraid:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    networks:
+      - tco-net
+
+networks:
+  tco-net:
+    driver: bridge

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,7 +242,7 @@ The application container image is identical for both paths. What differs is wha
 | Edge | Cloud HTTPS LB + Cloud Armor + managed cert | **Cloudflare Tunnel** (free tier) — provides public HTTPS without exposing the homelab IP, no port forwarding |
 | Public IP | Static GCP global IP | None — Cloudflare Tunnel terminates externally |
 | TLS | Google-managed cert | Cloudflare-managed at the tunnel edge |
-| Secrets | Secret Manager + External Secrets Operator | `.env` file outside the Git repo (e.g. `/mnt/user/appdata/tco/.env`), restricted file permissions; mounted into containers |
+| Secrets | Secret Manager + External Secrets Operator | `.env` file outside the Git repo (e.g. `/mnt/user/tco/.env`), restricted file permissions; mounted into containers |
 | Workload Identity | Yes (no keys mounted) | Static Google service account JSON key, read-only mounted into the backend container |
 | Backups | Cloud SQL automated + PITR | Daily `pg_dump` cron writing to Unraid storage; weekly off-host copy (e.g. to a NAS share or B2/S3 bucket) |
 | Monitoring | Cloud Logging + Cloud Monitoring | Container stdout → Unraid log viewer; optional self-hosted Grafana + Prometheus later |

--- a/scripts/db-init-unraid/01-roles.sh
+++ b/scripts/db-init-unraid/01-roles.sh
@@ -4,7 +4,7 @@
 # docker-entrypoint executes anything in /docker-entrypoint-initdb.d/ after
 # POSTGRES_USER / POSTGRES_DB are created).
 #
-# Passwords come from the Unraid host's /mnt/user/appdata/tco/.env via
+# Passwords come from the Unraid host's /mnt/user/tco/.env via
 # docker-compose env_file. No password may contain a single quote — the SQL
 # below interpolates them into single-quoted literals.
 

--- a/scripts/db-init-unraid/01-roles.sh
+++ b/scripts/db-init-unraid/01-roles.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Provision the three application roles documented in docs/architecture.md
+# § Multi-tenancy. Runs once at first Postgres container start (Postgres's
+# docker-entrypoint executes anything in /docker-entrypoint-initdb.d/ after
+# POSTGRES_USER / POSTGRES_DB are created).
+#
+# Passwords come from the Unraid host's /mnt/user/appdata/tco/.env via
+# docker-compose env_file. No password may contain a single quote — the SQL
+# below interpolates them into single-quoted literals.
+
+set -euo pipefail
+
+: "${TCO_APP_PASSWORD:?TCO_APP_PASSWORD must be set in .env}"
+: "${TCO_ADMIN_PASSWORD:?TCO_ADMIN_PASSWORD must be set in .env}"
+: "${TCO_MIGRATE_PASSWORD:?TCO_MIGRATE_PASSWORD must be set in .env}"
+
+psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<-SQL
+    CREATE ROLE tco_app     LOGIN PASSWORD '${TCO_APP_PASSWORD}';
+    CREATE ROLE tco_admin   LOGIN PASSWORD '${TCO_ADMIN_PASSWORD}' BYPASSRLS;
+    CREATE ROLE tco_migrate LOGIN PASSWORD '${TCO_MIGRATE_PASSWORD}' SUPERUSER;
+
+    GRANT CONNECT ON DATABASE ${POSTGRES_DB} TO tco_app, tco_admin, tco_migrate;
+
+    CREATE SCHEMA tco AUTHORIZATION tco_migrate;
+    GRANT USAGE, CREATE ON SCHEMA tco TO tco_app, tco_admin, tco_migrate;
+
+    GRANT USAGE ON SCHEMA public TO tco_app, tco_admin;
+    GRANT USAGE, CREATE ON SCHEMA public TO tco_migrate;
+
+    ALTER ROLE tco_app     SET search_path = tco, public;
+    ALTER ROLE tco_admin   SET search_path = tco, public;
+    ALTER ROLE tco_migrate SET search_path = tco, public;
+
+    ALTER DEFAULT PRIVILEGES FOR ROLE tco_migrate IN SCHEMA tco
+        GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO tco_app, tco_admin;
+    ALTER DEFAULT PRIVILEGES FOR ROLE tco_migrate IN SCHEMA tco
+        GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO tco_app, tco_admin;
+
+    CREATE EXTENSION IF NOT EXISTS pg_trgm SCHEMA public;
+SQL


### PR DESCRIPTION
First slice of the Unraid pilot deploy story (epic #67). Just Postgres for now — backend (with migrate one-shot), frontend, and cloudflared services land in follow-up PRs on top of this.

Closes part of #72 (the Postgres + role-init pieces); also overlaps with #76 (env discipline on Unraid).

## Summary

- **`docker-compose.unraid.yml`** with a single `postgres` service. Bind-mounts data to `/mnt/user/tco/postgres` so Unraid storage management sees it (vs. a named volume). No ports published — Postgres only reachable inside the `tco-net` bridge network the architecture doc names.
- **`scripts/db-init-unraid/01-roles.sh`** provisions the three roles (`tco_app`, `tco_admin` BYPASSRLS, `tco_migrate` SUPERUSER) using env-var-substituted passwords. Mirrors `scripts/db-init/01-roles.sql` but env-driven instead of hardcoded — different lifecycles deserve different init scripts, same principle as Spring profiles.
- **`.env.unraid.example`** documents the required keys. Real `.env` lives at `/mnt/user/tco/.env` (mode 0600, outside the repo) per #76's discipline.
- Architecture doc path updated from `/mnt/user/appdata/tco/.env` → `/mnt/user/tco/.env` to match the dedicated share.

## Test plan

- [x] `docker compose -f docker-compose.unraid.yml config` parses cleanly
- [x] Local smoke test (stubbed Unraid paths): three roles created with correct attributes; schema owned by `tco_migrate`; `tco_app` authenticates with env-supplied password
- [x] **Verified on the actual Unraid host**: `tco-postgres` up healthy; `\du tco_*` lists all three roles with the expected attribute markers
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)