### PR TITLE
Backend image to GHCR via CI (#70)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,9 @@ on:
   pull_request:
 
 # Two parallel build pipelines per docs/architecture.md § CI/CD.
-# Deploy jobs (deploy-unraid-*, deploy-prod-*) are not wired yet — they land
-# alongside the self-hosted runner setup in a follow-up PR.
+# build-and-push-* land the runtime images in GHCR on every main-branch
+# commit; deploy jobs (deploy-unraid-*, deploy-prod-*) pull from GHCR and
+# come later with the self-hosted runner setup.
 
 jobs:
   build-server:
@@ -112,4 +113,58 @@ jobs:
             echo "Run \`npm --prefix frontend run gen-api-types\` locally and commit the result."
             exit 1
           fi
+
+  # Image build + push. Main-branch commits only; PRs validate via build-server
+  # but don't publish. The same image (one set of tags per SHA) is the artifact
+  # for both Unraid pilot and future GCP prod deploys.
+  build-and-push-server:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-server
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build bootJar
+        run: ./gradlew :server:bootJar --stacktrace
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/cnau/tc-overwatch-server:sha-${SHORT_SHA}"
+            echo "ghcr.io/cnau/tc-overwatch-server:main"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: server/Dockerfile
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -306,7 +306,7 @@ On push to main:
   │  build-server (GH-A)    │    │  build-frontend (GH-A)  │
   │  1. setup Java 21       │    │  1. setup Node          │
   │  2. ./gradlew test      │    │  2. npm ci && npm test  │
-  │  3. bootBuildImage      │    │  3. npm run build       │
+  │  3. docker build        │    │  3. npm run build       │
   │  4. push → GHCR (SHA)   │    │  4. push static bundle  │
   │                          │    │     to GHCR (nginx     │
   │                          │    │     image) or asset    │

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -23,7 +23,8 @@
 ./gradlew :server:bootRun --args='--spring.profiles.active=local'
 ./gradlew :server:ktlintCheck :server:detekt
 ./gradlew :server:ktlintFormat                       # auto-fix style
-./gradlew :server:bootBuildImage                     # build OCI image
+./gradlew :server:bootJar                            # build executable JAR
+docker build -t tc-overwatch-server:dev -f server/Dockerfile .  # build runtime image
 ```
 
 Local dev assumes Postgres is up via `docker compose -f docker-compose.local.yml up -d postgres`.

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,23 @@
+# Backend runtime image. Assumes the bootJar is already built — CI runs
+# ./gradlew :server:bootJar before docker build, and uses the repo root as the
+# build context so this Dockerfile can reach server/build/libs/.
+#
+# Build locally:
+#   ./gradlew :server:bootJar
+#   docker build -t tc-overwatch-server:dev -f server/Dockerfile .
+
+FROM eclipse-temurin:23-jre
+
+LABEL org.opencontainers.image.source="https://github.com/cnau/tc-overwatch"
+LABEL org.opencontainers.image.description="tc-overwatch backend"
+
+WORKDIR /app
+
+RUN groupadd --system app && useradd --system --gid app --no-create-home app
+USER app:app
+
+COPY --chown=app:app server/build/libs/server-*-SNAPSHOT.jar /app/server.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/server.jar"]

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -26,8 +26,8 @@ kotlin {
     }
 }
 
-// Spring Boot Cloud Native Buildpacks — produces an OCI image without writing a Dockerfile.
-// Used by CI in the build-server pipeline; runs locally via `./gradlew :server:bootBuildImage`.
+// Embed build metadata in the JAR so /actuator/info can report version + commit.
+// The runtime image (server/Dockerfile) copies the bootJar produced here.
 springBoot {
     buildInfo()
 }


### PR DESCRIPTION
PR 1 of 2 for the backend slice of the Unraid pilot deploy story. This one only ships the runtime image and the CI job that publishes it to GHCR. PR 2 (next) wires the `backend` + `migrate` services into `docker-compose.unraid.yml`.

Refs #70.

## Summary

- **`server/Dockerfile`** — Temurin 23 JRE base (matches the local Gradle toolchain's bytecode level; verified the bootJar's class major version is 67 = Java 23). Non-root user, JAR copied from `server/build/libs/`. ~590MB.
- **New `build-and-push-server` job in `ci.yml`** — main-branch pushes only, not PRs. Builds the bootJar, builds the image, pushes to `ghcr.io/cnau/tc-overwatch-server` with `sha-<short>` and `main` tags. Auth via the built-in `GITHUB_TOKEN` — no extra secret to manage.
- **Architecture doc + `server/CLAUDE.md`** updated to reference `docker build` instead of `bootBuildImage`. The Paketo buildpack path is gone; the Dockerfile is the single source of truth for the image shape, matching the architecture doc's pin that "the same Dockerfile-built image runs everywhere."

## Test plan

- [x] `./gradlew :server:bootJar` produces a working JAR
- [x] `docker build -f server/Dockerfile .` succeeds locally (~590MB)
- [x] `docker run` starts the JVM, Spring Boot kicks in, then fails on missing JWT secret — expected; env-var wiring lands in PR 2
- [ ] CI green, including the new build-and-push-server job firing on this PR's main-merge
- [ ] Image visible on GHCR after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)