### PR TITLE
GHCR: prune old image versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,3 +168,14 @@ jobs:
           push: true
           tags: ${{ steps.tags.outputs.tags }}
 
+      # Stop GHCR from accumulating every commit's image forever. Keep the
+      # 5 most recent versions (latest carries :main + :sha-<short>; older
+      # 4 keep only their :sha-<short>). When we move to tagged releases,
+      # this prune can be tightened to keep :v* tags indefinitely.
+      - name: Prune old image versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: tc-overwatch-server
+          package-type: container
+          min-versions-to-keep: 5
+


### PR DESCRIPTION
Small follow-up to PR #98. Without pruning, every push to main left another ~590MB sha-tagged image sitting in GHCR forever — the 500MB private quota was gone after 1-2 pushes.

## Summary

- New \`Prune old image versions\` step in the \`build-and-push-server\` job uses [\`actions/delete-package-versions@v5\`](https://github.com/actions/delete-package-versions) with \`min-versions-to-keep: 5\`.
- Latest version (carrying \`:main\` + \`:sha-<short>\`) stays; next 4 keep only their \`:sha-<short>\`; older versions get pruned.
- 5 main commits of rollback granularity, plenty until we have multiple deploy environments and an actual release story.
- When tagged releases land (\`v0.1.0\` etc.), tighten further: keep \`:v*\` tags indefinitely, prune everything else.

(Separately: GHCR package visibility has been flipped to **public** to dodge the 500MB private-package quota entirely. The image stays linked to the still-private repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)