### PR TITLE
License: BSL 1.1 + README refresh

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,18 +1,60 @@
-Copyright (c) 2026 Christian Nau. All rights reserved.
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
 
-This source code and all associated materials are proprietary and
-confidential. No part of this codebase may be copied, modified, distributed,
-publicly disclosed, or used in any form — in source or binary — without the
-prior written consent of the copyright holder.
 
-Access to this repository does not grant any license to its contents. View
-or clone access (whether via GitHub collaborator invitation or otherwise) is
-permitted solely to enable review, discussion, and authorized contribution
-through GitHub's platform, and confers no rights beyond that purpose.
+Parameters
 
-Contributions submitted to this repository remain subject to a separate
-written agreement with the copyright holder; absent such an agreement, no
-contributions are accepted.
+Licensor:             Christian Nau
+Licensed Work:        tc-overwatch
+                      The Licensed Work is (c) 2026 Christian Nau.
+Additional Use Grant: Non-production use of the Licensed Work is permitted.
+Change Date:          2030-05-24
+Change License:       Apache License, Version 2.0
 
-THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED.
+For information about alternative licensing arrangements for the Licensed
+Work, please visit https://github.com/cnau/tc-overwatch.
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # tc-overwatch
 
+[![CI](https://github.com/cnau/tc-overwatch/actions/workflows/ci.yml/badge.svg)](https://github.com/cnau/tc-overwatch/actions/workflows/ci.yml)
+
 Transaction Overwatch for Transaction Coordinators.
 
 Automates the repetitive, time-consuming tasks that fill a real-estate transaction coordinator's day. Current focus: Gmail triage + sort + prioritize. See `GOALS.md` for full scope.
@@ -26,15 +28,17 @@ Automates the repetitive, time-consuming tasks that fill a real-estate transacti
 │       ├── application*.yml
 │       └── db/changelog/           # Liquibase Groovy DSL migrations
 ├── frontend/                       # React + TypeScript + Vite (deploys separately)
-├── deploy/helm/tc-overwatch-server/  # Helm chart for GKE
+├── deploy/helm/tc-overwatch-server/  # Helm chart for GKE (future prod target)
 ├── scripts/db-init/                # Local Postgres init (roles + extensions)
+├── scripts/db-init-unraid/         # Unraid Postgres init (env-driven passwords)
 ├── docker-compose.local.yml        # Local Postgres for development
-└── .github/workflows/ci.yml        # Parallel build pipelines (server + frontend)
+├── docker-compose.unraid.yml       # Unraid pilot deploy stack
+└── .github/workflows/ci.yml        # Build pipelines + GHCR image publish
 ```
 
 ## Local development
 
-Requires **JDK 21+** (Spring Boot 4 minimum; the current scaffold pins to JDK 23 because it was the locally-installed version on the dev machine — see `docs/architecture.md` § Scaffold notes for the foojay auto-download caveat), **Node 22+**, and **Docker**.
+Requires **JDK 21+** (Spring Boot 4 minimum; the Gradle toolchain pins to JDK 23, auto-provisioned via Foojay if not already installed), **Node 22+**, and **Docker**.
 
 ```bash
 # 1. Start local Postgres + role setup
@@ -48,11 +52,11 @@ cd frontend && npm install && npm run dev
 # → http://localhost:5173
 ```
 
-The Vite dev server proxies `/api/*` and `/oauth/*` to `localhost:8080` so the browser sees same-origin during development — no CORS needed locally.
+The Vite dev server proxies `/api/*`, `/oauth2/*`, and `/login/oauth2/*` to `localhost:8080` so the browser sees same-origin during development — no CORS needed locally.
 
 ## Status
 
-The current state is a scaffold: layered Spring Boot + Kotlin app with one smoke-test feature (`/api/ping`) exercising the full controller → service → DAO → repository → Postgres path. Real features land in subsequent branches.
+Pre-pilot. The auth + multi-tenancy foundation is live: Google OAuth sign-in via Spring Security `oauth2Login()`, invitation-only signup gate, bearer JWT paradigm, RLS-enforced multi-tenancy backed by a three-role Postgres setup. CI builds the backend image and pushes it to GHCR (`ghcr.io/cnau/tc-overwatch-server`) on every main commit. Deployment to the Unraid pilot stack is in progress — Postgres landed; backend, migrate, frontend, and Cloudflare Tunnel services come next. Real product features (email triage, transaction lifecycle, dashboard) land on top of this baseline — see `docs/task-inventory.md`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ The Vite dev server proxies `/api/*` and `/oauth/*` to `localhost:8080` so the b
 ## Status
 
 The current state is a scaffold: layered Spring Boot + Kotlin app with one smoke-test feature (`/api/ping`) exercising the full controller → service → DAO → repository → Postgres path. Real features land in subsequent branches.
+
+## License
+
+[Business Source License 1.1](./LICENSE). Non-production use is permitted today. On the Change Date (2030-05-24) the Licensed Work converts to the Apache License, Version 2.0. For commercial / production-use licensing, see the contact link in [LICENSE](./LICENSE).


### PR DESCRIPTION
Prep for flipping the repo to public.

## Summary

- **LICENSE** swapped from proprietary "all rights reserved" to **Business Source License 1.1**. Parameters:
  - Licensor: Christian Nau
  - Licensed Work: tc-overwatch (c) 2026 Christian Nau
  - Additional Use Grant: non-production use permitted
  - Change Date: 2030-05-24 (four-year BSL term)
  - Change License: Apache License, Version 2.0
- **README** refreshed to current reality:
  - CI status badge.
  - Status section rewritten — auth + multi-tenancy is live (Google OAuth, invitation gate, RLS, three-role Postgres); CI builds + publishes backend image to GHCR; Unraid pilot deploy in progress. The previous "scaffold with one smoke-test feature" framing was woefully outdated.
  - Layout block now includes `docker-compose.unraid.yml` and `scripts/db-init-unraid/`.
  - Vite proxy line corrected to `/api/*`, `/oauth2/*`, `/login/oauth2/*`.
  - JDK note tightened.
  - License section added.

## Test plan

- [x] LICENSE renders cleanly (60 lines, canonical BSL 1.1 body with my parameters spliced in)
- [x] README renders correctly in IDE preview
- [ ] CI green