### PR TITLE
Dedicated Liquibase migrate image; backend service on Unraid compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Top-level .dockerignore. Applies to every `docker build` in this repo
+# unless a per-Dockerfile <name>.dockerignore overrides.
+#
+# Goal: keep the build context small (the migrate image only needs
+# server/src/main/resources/db/changelog; the server image only needs
+# server/build/libs/server-*-SNAPSHOT.jar — everything else is waste).
+
+# Version control + repo metadata
+.git
+.gitignore
+.gitattributes
+.github
+
+# Editor / IDE
+**/.idea
+**/.vscode
+**/*.iml
+**/.DS_Store
+
+# Local-only env files (production secrets live outside the repo)
+**/.env
+**/.env.local
+**/.env.*.local
+
+# Build outputs — broadly excluded; the bootJar that server/Dockerfile copies
+# is the one re-inclusion needed.
+**/build
+**/dist
+**/node_modules
+**/.gradle
+**/.next
+**/.cache
+**/coverage
+
+!server/build
+!server/build/libs
+!server/build/libs/**

--- a/.env.unraid.example
+++ b/.env.unraid.example
@@ -10,7 +10,22 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=
 
 # --- Application role passwords (consumed by scripts/db-init-unraid/01-roles.sh
-#     at first DB init, and later by the backend via Spring config) -------------
+#     at first DB init, and later by the backend + migrate containers) ----------
 TCO_APP_PASSWORD=
 TCO_ADMIN_PASSWORD=
 TCO_MIGRATE_PASSWORD=
+
+# --- Backend (consumed by the backend container) -------------------------------
+# HS256 JWT signing secret (≥32 bytes). Generate with `openssl rand -base64 32`.
+AUTH_JWT_SECRET=
+
+# Google OAuth client for the Unraid hostname (issued in Google Cloud Console).
+# Unset until production OAuth client lands (#75) — the OAuth security filter
+# chain is conditional on GOOGLE_CLIENT_ID, so an empty value disables OAuth
+# login until both halves are configured.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# Where the OAuth success handler redirects the SPA back to. Will be the
+# Cloudflare Tunnel frontend hostname once #74 lands; placeholder until then.
+APP_FRONTEND_BASE_URL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Boot Postgres (compose mounts the role-provisioning init script)
-        run: docker compose -f docker-compose.local.yml up -d --wait
+        run: docker compose -f docker-compose.local.yml up -d --wait postgres
+
+      - name: Build migrate image
+        run: docker compose -f docker-compose.local.yml build migrate
+
+      - name: Apply migrations
+        run: docker compose -f docker-compose.local.yml run --rm migrate
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -179,3 +185,51 @@ jobs:
           package-type: container
           min-versions-to-keep: 5
 
+  # Liquibase migration image. Gated on build-server so the migrate image and
+  # the server image stay versioned in lockstep on the `:main` tag — entities
+  # and changelogs are coupled by JPA's ddl-auto validate at backend startup.
+  build-and-push-migrate:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-server
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/cnau/tc-overwatch-migrate:sha-${SHORT_SHA}"
+            echo "ghcr.io/cnau/tc-overwatch-migrate:main"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: migrate/Dockerfile
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+
+      - name: Prune old image versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: tc-overwatch-migrate
+          package-type: container
+          min-versions-to-keep: 5

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,8 +1,8 @@
-# Local-dev infrastructure. Bring up Postgres before running the server.
+# Local-dev infrastructure. Bring up Postgres + apply migrations, then run the
+# backend from your IDE or the CLI:
 #
-#   docker compose -f docker-compose.local.yml up -d
-#
-# Then run the server from your IDE or:
+#   docker compose -f docker-compose.local.yml up -d postgres
+#   docker compose -f docker-compose.local.yml run --rm migrate
 #   ./gradlew :server:bootRun --args='--spring.profiles.active=local'
 #
 # Frontend separately:
@@ -28,6 +28,24 @@ services:
       interval: 5s
       timeout: 3s
       retries: 20
+
+  # One-shot Liquibase runner. `image:` pulls from GHCR for normal use;
+  # `build:` lets local devs `docker compose build migrate` before the image
+  # has been published. Invoke via `docker compose run --rm migrate`.
+  migrate:
+    image: ghcr.io/cnau/tc-overwatch-migrate:main
+    build:
+      context: .
+      dockerfile: migrate/Dockerfile
+    container_name: tco-migrate
+    restart: "no"
+    environment:
+      LIQUIBASE_COMMAND_URL: jdbc:postgresql://postgres:5432/tco
+      LIQUIBASE_COMMAND_USERNAME: tco_migrate
+      LIQUIBASE_COMMAND_PASSWORD: tco_migrate_local_password
+    depends_on:
+      postgres:
+        condition: service_healthy
 
 volumes:
   tco-postgres-data:

--- a/docker-compose.unraid.yml
+++ b/docker-compose.unraid.yml
@@ -1,12 +1,19 @@
 # Unraid pilot stack. Bring up via:
 #
-#   docker compose -f docker-compose.unraid.yml up -d
+#   docker compose -f docker-compose.unraid.yml \
+#     --env-file /mnt/user/tco/.env up -d
 #
-# Secrets come from /mnt/user/tco/.env (mode 0600, outside the repo).
-# See .env.unraid.example for the required keys.
+# Two independent uses of the same .env file:
+#   - `--env-file` feeds compose's ${VAR} interpolation in THIS file.
+#   - `env_file:` directives below pass variables through to each container.
+# Forgetting `--env-file` fails fast with a clear "missing X" error (via the
+# ${VAR:?...} fallbacks below), rather than silently substituting empty
+# strings. The .env file lives at /mnt/user/tco/.env with mode 0600, outside
+# the repo. See .env.unraid.example for the required keys.
 #
-# Backend, migrate, frontend, and cloudflared services land in later commits
-# on this branch.
+# Frontend (Nginx + static bundle from GHCR) and cloudflared (Cloudflare
+# Tunnel connector) services land in later commits — blocked on the frontend
+# OCI image (#71) and Cloudflare Tunnel hostname registration (#74 / #75).
 
 services:
   postgres:
@@ -25,6 +32,40 @@ services:
       retries: 20
     networks:
       - tco-net
+
+  migrate:
+    image: ghcr.io/cnau/tc-overwatch-migrate:main
+    container_name: tco-migrate
+    restart: "no"
+    env_file:
+      - /mnt/user/tco/.env
+    environment:
+      LIQUIBASE_COMMAND_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:?missing — pass --env-file /mnt/user/tco/.env}
+      LIQUIBASE_COMMAND_USERNAME: tco_migrate
+      LIQUIBASE_COMMAND_PASSWORD: ${TCO_MIGRATE_PASSWORD:?missing — pass --env-file /mnt/user/tco/.env}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - tco-net
+
+  backend:
+    image: ghcr.io/cnau/tc-overwatch-server:main
+    container_name: tco-backend
+    restart: unless-stopped
+    env_file:
+      - /mnt/user/tco/.env
+    environment:
+      SPRING_PROFILES_ACTIVE: unraid
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    networks:
+      - tco-net
+    # Healthcheck deferred: the eclipse-temurin:23-jre base lacks curl/wget,
+    # and nothing else in the stack currently depends_on backend's health.
 
 networks:
   tco-net:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ The implementation stack. Decisions locked here are the result of explicit requi
 | JVM | 21+ | Spring Boot 4 requires it |
 | Backend | Spring Boot 4.0.6 + Kotlin | Bleeding edge — watch third-party compat |
 | Database | Postgres 18 | `pg_trgm` for fuzzy match, `JSONB` for flexible fields |
-| Migrations | Liquibase (Groovy DSL) | Changelogs in `src/main/resources/db/changelog/`; runs via the `migrate` one-shot container as `tco_migrate` |
+| Migrations | Liquibase (Groovy DSL) | Changelogs in `server/src/main/resources/db/changelog/`, baked into the dedicated `tc-overwatch-migrate` Docker image (`migrate/Dockerfile`). Runs as the `tco_migrate` role; not on the server's classpath. |
 | API wire format | HTTP / JSON | Spring MVC `@RestController` + Jackson |
 | Frontend | React + TypeScript + Vite | TanStack Query + `fetch` |
 | Background jobs | Postgres-backed queue (Spring `@Scheduled` + `LISTEN/NOTIFY`) | Upgrade to Temporal only if SaaS scale demands |
@@ -26,7 +26,7 @@ The implementation stack. Decisions locked here are the result of explicit requi
 ### Persistence and ORM
 
 - **Spring Data JPA + Hibernate** for persistence.
-- **Liquibase (Groovy DSL)** for schema migrations. Changelogs in `src/main/resources/db/changelog/`. Run by a one-shot `migrate` container in the deploy workflow as the `tco_migrate` role, never on app startup.
+- **Liquibase (Groovy DSL)** for schema migrations. Changelogs in `server/src/main/resources/db/changelog/`. Run by a **dedicated `tc-overwatch-migrate` Docker image** (`migrate/Dockerfile`, based on the upstream `liquibase/liquibase` image) — the server's classpath is intentionally Liquibase-free. The migrate container runs to completion as the `tco_migrate` role before the backend starts, in every environment (local-dev, Unraid pilot, GCP prod).
 
 ### Layered architecture
 
@@ -294,35 +294,35 @@ Schema, code, and business logic don't change at all — only the deployment env
 
 ## CI/CD
 
-GitHub Actions for the pipeline; GitHub Container Registry (GHCR) for the image. One built image is the artifact for *both* deployment paths (Unraid pilot now, GCP later) — no per-environment image variants. Promotion is "did the same image deploy successfully to environment X?"
+GitHub Actions for the pipeline; GitHub Container Registry (GHCR) for the images. Each built image is the artifact for *both* deployment paths (Unraid pilot now, GCP later) — no per-environment image variants. Promotion is "did the same image deploy successfully to environment X?"
 
 ### Pipeline shape
 
-**Two parallel build pipelines** (one per codebase), each with its own deploy fan-out:
+**Three parallel build pipelines** (server, migrate, frontend), each shipping its own immutable image and with its own deploy fan-out:
 
 ```
 On push to main:
-  ┌─────────────────────────┐    ┌─────────────────────────┐
-  │  build-server (GH-A)    │    │  build-frontend (GH-A)  │
-  │  1. setup Java 21       │    │  1. setup Node          │
-  │  2. ./gradlew test      │    │  2. npm ci && npm test  │
-  │  3. docker build        │    │  3. npm run build       │
-  │  4. push → GHCR (SHA)   │    │  4. push static bundle  │
-  │                          │    │     to GHCR (nginx     │
-  │                          │    │     image) or asset    │
-  │                          │    │     store              │
-  └────────────┬─────────────┘    └────────────┬────────────┘
-               │                                │
-         ┌─────┴──────┐                  ┌──────┴──────┐
-         ▼            ▼                  ▼             ▼
-   ┌──────────┐  ┌──────────┐      ┌──────────┐  ┌──────────┐
-   │ deploy-  │  │ deploy-  │      │ deploy-  │  │ deploy-  │
-   │ unraid-  │  │ prod-    │      │ unraid-  │  │ prod-    │
-   │ server   │  │ server   │      │ frontend │  │ frontend │
-   └──────────┘  └──────────┘      └──────────┘  └──────────┘
+  ┌────────────────────┐   ┌────────────────────┐   ┌────────────────────┐
+  │  build-server      │   │  build-migrate     │   │  build-frontend    │
+  │  Java 21 + Gradle  │   │  liquibase + ext'n │   │  Node + Vite       │
+  │  ./gradlew test    │   │  docker build      │   │  npm ci + build    │
+  │  bootJar           │   │  push → GHCR       │   │  static bundle →   │
+  │  docker build      │   │   tc-overwatch-    │   │  GHCR (nginx       │
+  │  push → GHCR       │   │   migrate          │   │  image)            │
+  │   tc-overwatch-    │   │                    │   │                    │
+  │   server           │   │                    │   │                    │
+  └─────────┬──────────┘   └─────────┬──────────┘   └─────────┬──────────┘
+            │                        │                        │
+      ┌─────┴──────┐                 │                  ┌─────┴──────┐
+      ▼            ▼                 ▼                  ▼            ▼
+┌──────────┐  ┌──────────┐    (consumed by         ┌──────────┐  ┌──────────┐
+│ deploy-  │  │ deploy-  │     deploy-unraid-      │ deploy-  │  │ deploy-  │
+│ unraid-  │  │ prod-    │     server's migrate    │ unraid-  │  │ prod-    │
+│ server   │  │ server   │     step + the local-   │ frontend │  │ frontend │
+└──────────┘  └──────────┘     dev compose)        └──────────┘  └──────────┘
 ```
 
-Frontend and backend deploys are independent. Either can ship without the other. The contract between them is the JSON shape of the HTTP API — kept aligned by review today, and slated to be enforced by OpenAPI codegen + CI drift check per issue #83.
+Server, migrate, and frontend deploys are independent. Any one can ship without the others. The frontend↔backend contract is the JSON shape of the HTTP API, kept aligned by OpenAPI codegen + CI drift check (per issue #83); migrate↔backend coupling is the schema, kept aligned by review (an entity field change ships with a migration changeset in the same PR).
 
 ### Unraid deploy: self-hosted runner
 

--- a/docs/claude/liquibase.md
+++ b/docs/claude/liquibase.md
@@ -20,7 +20,13 @@ server/src/main/resources/db/changelog/
 
 Register each new changelog file in the master with an explicit `include file:` entry — no `includeAll`. The master file is just an ordered list of includes, one per changelog file.
 
-Migrations run as the `tco_migrate` role. Production: one-shot `migrate` container completes before backend starts. Local: Spring Boot runs them on startup as a dev shortcut.
+Migrations run as the `tco_migrate` role from the **dedicated `migrate` Docker image** (`migrate/Dockerfile`) — Liquibase is intentionally not on the Spring Boot server's classpath. Same one-shot container pattern in every environment:
+
+```
+docker compose -f docker-compose.local.yml run --rm migrate
+```
+
+The image bakes the changelogs in at build time, so the deployed changelog version is locked to the image SHA. See `docs/architecture.md` § CI/CD for the deploy ordering (postgres healthy → migrate completes → backend starts).
 
 ## Changeset naming
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,6 @@
 kotlin                  = "2.2.0"
 springBoot              = "4.0.6"
 springDepMgmt           = "1.1.7"
-liquibase               = "4.32.0"
-liquibaseGroovyDsl      = "4.0.0"
 postgresJdbc            = "42.7.7"
 testcontainers          = "1.21.3"
 junit                   = "5.12.0"
@@ -34,12 +32,8 @@ springBoot-starter-test             = { module = "org.springframework.boot:sprin
 # Kotlin nullability. 3.x is the Spring Boot 4 / Spring Framework 7 line.
 springdoc-openapi-webmvc-ui         = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdocOpenapi" }
 
-# Persistence
+# Persistence (Liquibase lives in the separate `migrate` Docker image — `migrate/Dockerfile`)
 postgres-jdbc                       = { module = "org.postgresql:postgresql", version.ref = "postgresJdbc" }
-liquibase-core                      = { module = "org.liquibase:liquibase-core", version.ref = "liquibase" }
-liquibase-groovyDsl                 = { module = "org.liquibase:liquibase-groovy-dsl", version.ref = "liquibaseGroovyDsl" }
-# Spring Boot 4 split per-feature autoconfig into separate modules; spring-boot-liquibase is no longer transitive via data-jpa
-springBoot-liquibase                = { module = "org.springframework.boot:spring-boot-liquibase" }
 
 # Kotlin
 kotlin-reflect                      = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }

--- a/migrate/Dockerfile
+++ b/migrate/Dockerfile
@@ -1,0 +1,41 @@
+# Liquibase one-shot migration image. Independent of the Spring Boot server:
+# this is the only place Liquibase lives.
+#
+# Build locally (from repo root):
+#   docker build -t tc-overwatch-migrate:dev -f migrate/Dockerfile .
+#
+# To bump the base image: `docker pull liquibase/liquibase:<new-tag>` then copy
+# the printed digest into the FROM line below.
+
+FROM liquibase/liquibase:4.32@sha256:fbee3db36feece76da4207e9cca12873efecc057aba074232338bff600c19246
+
+LABEL org.opencontainers.image.source="https://github.com/cnau/tc-overwatch"
+LABEL org.opencontainers.image.description="tc-overwatch Liquibase migrations"
+
+# Groovy DSL extension — our changelogs are *.groovy. Not in lpm's catalog,
+# so pulled directly from Maven Central with SHA-256 pins (BuildKit verifies
+# before COPY). Groovy 3.0.17 matches what liquibase-groovy-dsl 4.0.0 resolves
+# transitively. To bump a version: update the URL + checksum together (fetch
+# the new checksum from Maven Central's `<jar>.sha256` sibling file).
+ADD --chown=liquibase:liquibase \
+    --checksum=sha256:881525567caae594701228279857d90953b77bf3f48cf4925f844487dc61d749 \
+    https://repo1.maven.org/maven2/org/liquibase/liquibase-groovy-dsl/4.0.0/liquibase-groovy-dsl-4.0.0.jar \
+    /liquibase/lib/
+ADD --chown=liquibase:liquibase \
+    --checksum=sha256:9ed2a565a8592a9f63f410afed892d0ca6bec1ff96277ce4cc7f3e2e366e794f \
+    https://repo1.maven.org/maven2/org/codehaus/groovy/groovy/3.0.17/groovy-3.0.17.jar \
+    /liquibase/lib/
+ADD --chown=liquibase:liquibase \
+    --checksum=sha256:b78710a77fb7c7973d613448db99a08d2f880e040e82981900fb645f726bfe31 \
+    https://repo1.maven.org/maven2/org/codehaus/groovy/groovy-sql/3.0.17/groovy-sql-3.0.17.jar \
+    /liquibase/lib/
+
+COPY --chown=liquibase:liquibase \
+    server/src/main/resources/db/changelog \
+    /liquibase/changelog
+
+CMD ["--search-path=/liquibase/changelog", \
+     "--changelog-file=db.changelog-master.groovy", \
+     "--default-schema-name=tco", \
+     "--liquibase-schema-name=public", \
+     "update"]

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -11,7 +11,7 @@
 - The HTTP/JSON API surface (Spring MVC `@RestController`s in `feature/<name>/api/`, at `/api/*`).
 - The OAuth start/callback, auth endpoints, and actuator health (per `docs/architecture.md` § HTTP surface).
 - Business logic in feature-scoped services (`feature/<name>/service/`).
-- JPA persistence with Liquibase-managed schema (`feature/<name>/persistence/`, `src/main/resources/db/changelog/`).
+- JPA persistence (`feature/<name>/persistence/`). The schema is owned by the **separate `migrate` Docker image** (`migrate/Dockerfile`); changelogs at `src/main/resources/db/changelog/` are read by that image at build time. Liquibase is intentionally not on the server's classpath.
 - Background jobs via the Postgres-backed work queue (per `docs/architecture.md` § Background jobs — none implemented yet).
 
 ## Commands
@@ -27,7 +27,15 @@
 docker build -t tc-overwatch-server:dev -f server/Dockerfile .  # build runtime image
 ```
 
-Local dev assumes Postgres is up via `docker compose -f docker-compose.local.yml up -d postgres`.
+Local dev sequence:
+
+```
+docker compose -f docker-compose.local.yml up -d --wait postgres
+docker compose -f docker-compose.local.yml run --rm migrate     # one-shot Liquibase
+./gradlew :server:bootRun --args='--spring.profiles.active=local'
+```
+
+Migrations live in the `tc-overwatch-migrate` image (`migrate/Dockerfile`). While the image isn't yet on GHCR (pre-merge), first-time local devs run `docker compose -f docker-compose.local.yml build migrate` to compile it locally; afterwards `compose pull migrate` keeps it fresh.
 
 ## Ports
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,5 +1,6 @@
 // :server — the Spring Boot application. HTTP/JSON API (Spring MVC + Jackson), JPA persistence,
-// Liquibase migrations, Kotlin extension-function boundary mappers, feature-by-package layout.
+// Kotlin extension-function boundary mappers, feature-by-package layout.
+// Liquibase lives in the separate `migrate` Docker image — not on this classpath.
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -52,9 +53,6 @@ dependencies {
 
     // Persistence
     runtimeOnly(libs.postgres.jdbc)
-    implementation(libs.liquibase.core)
-    implementation(libs.liquibase.groovyDsl)
-    implementation(libs.springBoot.liquibase) // SB4 moved Liquibase autoconfig to its own module
 
     // Kotlin
     implementation(libs.kotlin.reflect)

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -8,16 +8,6 @@ spring:
     password: tco_app_local_password
     driver-class-name: org.postgresql.Driver
 
-  # In local dev, Liquibase runs at startup for convenience (no separate migrate container).
-  # Migrations run as tco_migrate so (a) tables are owned by a different role than
-  # the app uses, which means RLS actually filters tco_app's queries (owners
-  # bypass RLS by default), and (b) only tco_migrate has CREATE on public for
-  # Liquibase's own bookkeeping tables.
-  liquibase:
-    enabled: true
-    user: tco_migrate
-    password: tco_migrate_local_password
-
   jpa:
     show-sql: true
     properties:

--- a/server/src/main/resources/application-unraid.yml
+++ b/server/src/main/resources/application-unraid.yml
@@ -1,0 +1,17 @@
+# Unraid pilot profile. Activate via SPRING_PROFILES_ACTIVE=unraid.
+# Pairs with docker-compose.unraid.yml — backend reads its config from the
+# .env file mounted into the container at /mnt/user/tco/.env on the host.
+
+spring:
+  datasource:
+    url: jdbc:postgresql://postgres:5432/${POSTGRES_DB}
+    username: tco_app
+    password: ${TCO_APP_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+auth:
+  jwt:
+    secret: ${AUTH_JWT_SECRET}
+
+app:
+  frontend-base-url: ${APP_FRONTEND_BASE_URL}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -6,18 +6,6 @@ spring:
     name: tc-overwatch
     version: 0.0.1
 
-  # Liquibase migration changelog. In production, migrations are run by a one-shot
-  # `migrate` container (the `tco_migrate` DB role) before the backend starts, with
-  # `spring.liquibase.enabled=false` set via that profile. Local-dev runs migrations
-  # at app startup using the autoconfig default (enabled when on the classpath).
-  liquibase:
-    change-log: classpath:/db/changelog/db.changelog-master.groovy
-    # App data lives in `tco`. Liquibase's own bookkeeping tables
-    # (databasechangelog, databasechangeloglock) stay in `public` — they're
-    # framework infrastructure, not domain data.
-    default-schema: tco
-    liquibase-schema: public
-
   jpa:
     hibernate:
       ddl-auto: validate   # never auto-modify schema; Liquibase owns it


### PR DESCRIPTION
## Summary

Pivots #72 to a dedicated `tc-overwatch-migrate` Docker image (`migrate/Dockerfile`, based on `liquibase/liquibase:4.32` + Groovy DSL extension from Maven Central) and yanks Liquibase out of the server entirely. One-shot migrate container pattern is now identical across local dev, Unraid pilot, and future GCP prod.

- New `migrate/Dockerfile` + `build-and-push-migrate` CI job (gated on `build-server` to keep the migrate + server images versioned in lockstep on the `:main` tag).
- `docker-compose.unraid.yml` gains `migrate` + `backend` services; backend `depends_on: { migrate: service_completed_successfully }`. Header documents `--env-file /mnt/user/tco/.env`; `${VAR:?...}` fail-fast guards a forgotten flag.
- Server stripped of `liquibase-core`, `liquibase-groovy-dsl`, `spring-boot-liquibase`; `spring.liquibase.*` blocks removed from `application.yml` + `application-local.yml`.
- Local dev sequence: `compose up -d --wait postgres` → `compose run --rm migrate` → `gradlew bootRun`. CI's `api-type-drift` job updated to match.
- New `.dockerignore` drops migrate's build context from ~278MB to ~1KB while preserving `server/build/libs/**` for the server Dockerfile.
- All three Maven Central JARs are SHA-256 pinned; base image pinned by digest.

Closes #72.

Frontend + cloudflared services in `docker-compose.unraid.yml` still deferred — blocked on #71 (frontend OCI image) and #74 / #75 (Cloudflare Tunnel + production OAuth client).

## Test plan

- [x] `./gradlew :server:build :server:ktlintCheck` passes without Liquibase on the classpath
- [x] `docker build -f migrate/Dockerfile .` succeeds with pinned digests + checksums; build context transfer is ~1KB
- [x] `docker compose -f docker-compose.unraid.yml config` (no `--env-file`) fails fast with `required variable POSTGRES_DB is missing a value: missing — pass --env-file /mnt/user/tco/.env`
- [x] Happy-path compose interpolation resolves past `${VAR:?...}` with a populated env file
- [x] Local sequence end-to-end against fresh Postgres: 6 changesets applied; second run is "Database is up to date, no changesets to execute"
- [x] Backend boots in ~2s against the migrated schema; `/actuator/health` returns `UP`
- [ ] CI green on this PR
- [ ] After merge: confirm `ghcr.io/cnau/tc-overwatch-migrate:main` is published alongside `tc-overwatch-server:main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)