### PR TITLE
Frontend OCI image: Nginx + Vite bundle, published to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,54 @@ jobs:
           package-type: container
           min-versions-to-keep: 5
 
+  # Frontend image — Nginx + static Vite bundle. Gated on build-frontend so
+  # the published image always reflects a passing type-check + lint + bundle.
+  build-and-push-frontend:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-frontend
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/cnau/tc-overwatch-frontend:sha-${SHORT_SHA}"
+            echo "ghcr.io/cnau/tc-overwatch-frontend:main"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: frontend/Dockerfile
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+
+      - name: Prune old image versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: tc-overwatch-frontend
+          package-type: container
+          min-versions-to-keep: 5
+
   # Liquibase migration image. Gated on build-server so the migrate image and
   # the server image stay versioned in lockstep on the `:main` tag — entities
   # and changelogs are coupled by JPA's ddl-auto validate at backend startup.

--- a/.run/Backend.run.xml
+++ b/.run/Backend.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Backend" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+  <configuration default="false" name="Backend" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="local">
     <option name="ACTIVE_PROFILES" value="local" />
     <module name="tc-overwatch.server.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="com.tcoverwatch.Application" />

--- a/.run/Frontend.run.xml
+++ b/.run/Frontend.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Frontend" type="js.build_tools.npm">
+  <configuration default="false" name="Frontend" type="js.build_tools.npm" folderName="local">
     <package-json value="$PROJECT_DIR$/frontend/package.json" />
     <command value="run" />
     <scripts>

--- a/.run/Postgres.run.xml
+++ b/.run/Postgres.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Postgres" type="ShConfigurationType">
+  <configuration default="false" name="Postgres" type="ShConfigurationType" folderName="local">
     <option name="SCRIPT_TEXT" value="docker compose -f docker-compose.local.yml up -d --wait" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
     <option name="SCRIPT_PATH" value="" />

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -17,9 +17,14 @@ npm run dev                # Vite dev server on :5173
 npm run build              # type-check + production bundle into dist/
 npm run lint               # ESLint
 npm run preview            # preview the production build locally
+docker build -t tc-overwatch-frontend:dev -f frontend/Dockerfile .   # runtime image (Nginx + bundle)
 ```
 
 Run from the repo root with `npm --prefix frontend run <script>` when chaining with backend commands.
+
+## Production runtime
+
+The deployable artifact is `ghcr.io/cnau/tc-overwatch-frontend` — a small Nginx image serving the Vite bundle. Built and pushed by CI (`build-and-push-frontend`) on every push to `main`; `frontend/Dockerfile` is multi-stage (`node:22-alpine` builder → `nginx:1.27-alpine` runtime). `frontend/nginx.conf` configures: SPA fallback to `index.html`, immutable 1-year cache on Vite's content-hashed assets, no-cache on the entry document, and explicit 404s on `/api/*` + `/oauth2/*` (the backend lives on a separate hostname; if a real backend request reaches this Nginx, something's misconfigured and we'd rather fail cleanly than fall through to the SPA shell).
 
 ## Module-specific notes
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,31 @@
+# Frontend runtime image: Nginx serving the production Vite bundle.
+#
+# Build locally (from repo root):
+#   docker build -t tc-overwatch-frontend:dev -f frontend/Dockerfile .
+#
+# To bump a base image: `docker pull <ref>` and copy the printed digest into
+# the FROM line below.
+
+# --- Stage 1: build the Vite bundle ---
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS builder
+
+WORKDIR /app
+
+# Install deps in a separate layer so source-only changes don't bust the cache.
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
+# Source tree (build context is repo root; .dockerignore strips node_modules/dist).
+COPY frontend/ ./
+RUN npm run build
+
+# --- Stage 2: Nginx runtime ---
+FROM nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
+
+LABEL org.opencontainers.image.source="https://github.com/cnau/tc-overwatch"
+LABEL org.opencontainers.image.description="tc-overwatch frontend (Nginx + static bundle)"
+
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,34 @@
+server {
+    listen 80 default_server;
+    server_name _;
+    root /usr/share/nginx/html;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 256;
+    gzip_proxied any;
+    gzip_types text/plain text/css text/javascript application/javascript application/json application/xml+rss image/svg+xml;
+
+    # The backend lives on a separate hostname (api.<domain>). If a /api/* or
+    # /oauth2/* request reaches *this* nginx, the SPA is misconfigured — fail
+    # cleanly with 404 instead of falling through to index.html (which would
+    # surface as confusing HTML-decoded-as-JSON errors in the browser).
+    location /api/      { return 404; }
+    location /oauth2/   { return 404; }
+    location /login/oauth2/ { return 404; }
+
+    # Hashed assets (Vite emits filenames like `assets/index-<hash>.js`) — cache
+    # forever; the hash invalidates on change.
+    location ~* \.(?:js|css|woff2|woff|ttf|eot|svg|png|jpg|jpeg|gif|webp|ico)$ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
+    # SPA fallback — any other route serves index.html so the React Router can
+    # take over. Don't cache the entry document; new bundles ship under new
+    # asset hashes referenced from a fresh index.html.
+    location / {
+        try_files $uri /index.html;
+        add_header Cache-Control "no-cache";
+    }
+}


### PR DESCRIPTION
## Summary

Closes #71.

- **`frontend/Dockerfile`** — multi-stage build: `node:22-alpine` builder runs `npm ci && npm run build`; `nginx:1.27-alpine` runtime serves `dist/`. Both base images digest-pinned (matches the `migrate/Dockerfile` pattern from #101).
- **`frontend/nginx.conf`** — SPA fallback to `/index.html`; immutable 1-year cache on Vite's hashed assets; no-cache on the entry document; explicit 404 on `/api/`, `/oauth2/`, `/login/oauth2/` (the backend lives on a separate hostname — if a real backend request reaches *this* Nginx, the SPA is misconfigured and we'd rather fail cleanly than fall through to the SPA shell); gzip on.
- **CI** — new `build-and-push-frontend` job, gated on `build-frontend` (type-check + lint + bundle). Tags `:sha-<short>` + `:main` and prunes to 5 versions, matching server + migrate.
- **Docs** — `frontend/CLAUDE.md` gains a "Production runtime" section pointing at the new artifact + nginx config.

## Out of scope (deliberate)

- **Runtime API base URL injection.** The SPA uses relative URLs today; in production it'll live at `app.<domain>` while the backend is at `api.<domain>`. Making cross-origin calls work needs runtime config (env var → `/config.js` → `window.__APP_CONFIG__`, or similar). Worth a dedicated issue before the image actually ships to the pilot.
- **Wiring the frontend service into `docker-compose.unraid.yml`.** The compose comment notes it's still blocked on the Cloudflare Tunnel hostnames (#74) and prod OAuth client (#75); landing the service entry can ride alongside that work.

## Test plan

- [x] `docker build -f frontend/Dockerfile .` succeeds end-to-end on Apple Silicon laptop
- [x] `GET /` returns the SPA shell with `Cache-Control: no-cache`
- [x] SPA fallback: unmatched route (e.g. `/some/random/route`) returns 200 with the SPA shell
- [x] Hashed asset (`/assets/index-<hash>.js`) returns 200 with `Cache-Control: public, max-age=31536000, immutable` (single header, not duplicated)
- [x] `/api/ping`, `/oauth2/authorization/google`, `/login/oauth2/code/google` each return 404 cleanly (no SPA fallthrough)
- [ ] CI green on this PR
- [ ] After merge: `ghcr.io/cnau/tc-overwatch-frontend:main` and `:sha-<short>` published alongside the server + migrate images

🤖 Generated with [Claude Code](https://claude.com/claude-code)