### PR TITLE
Frontend runtime config: env-driven /config.js + apiBaseUrl prepending

### DIFF
--- a/.env.unraid.example
+++ b/.env.unraid.example
@@ -29,3 +29,10 @@ GOOGLE_CLIENT_SECRET=
 # Where the OAuth success handler redirects the SPA back to. Will be the
 # Cloudflare Tunnel frontend hostname once #74 lands; placeholder until then.
 APP_FRONTEND_BASE_URL=
+
+# --- Frontend (consumed by the frontend container, once it's wired into the
+#     unraid compose) ---------------------------------------------------------
+# Absolute URL of the backend, baked into /config.js at container start. The
+# SPA prepends this to every leading-slash API request. Will be the Cloudflare
+# Tunnel backend hostname once #74 lands.
+APP_API_BASE_URL=

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,6 +123,12 @@ Where the frontend lives per environment:
 - **Unraid pilot**: separate `nginx`-based container hosting the static build, on its own Cloudflare Tunnel hostname (e.g. `app.example.com` for the frontend, `api.example.com` for the backend). Each tunnel hostname is independent; either can be deployed without touching the other.
 - **GCP production**: frontend built and pushed to **Cloud Storage + Cloud CDN** (or a small Cloud Run static container — pick later). Backend on GKE. Two distinct deploy pipelines.
 
+#### Runtime configuration — one image, env-driven `/config.js`
+
+The same `tc-overwatch-frontend` image deploys to every environment. Environment-specific values (today just the backend's absolute URL) ride in via env vars and are written to `/usr/share/nginx/html/config.js` at container start (`frontend/docker-entrypoint.d/40-generate-config-js.sh`). `index.html` loads `/config.js` as a classic synchronous script before the deferred React bundle; `window.__APP_CONFIG__` is always populated before bundle code reads it. `frontend/src/api/http.ts` prepends `apiBaseUrl` to leading-slash request paths.
+
+Build-time `VITE_*` env vars were rejected because they'd bake the backend URL into the bundle — different image per environment, defeating the "one artifact, multiple deploys" model the server + migrate images already follow. A small startup script and a synchronous tag in `index.html` is the cost; one immutable image per `:main` SHA is the payoff.
+
 ### CORS for cross-origin SPA
 
 Because frontend and backend live on different origins, CORS is a day-one config — but it's simpler in the bearer paradigm than it would be with session cookies (no `Allow-Credentials`, no parent-domain alignment, no SameSite considerations):

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -26,6 +26,18 @@ Run from the repo root with `npm --prefix frontend run <script>` when chaining w
 
 The deployable artifact is `ghcr.io/cnau/tc-overwatch-frontend` — a small Nginx image serving the Vite bundle. Built and pushed by CI (`build-and-push-frontend`) on every push to `main`; `frontend/Dockerfile` is multi-stage (`node:22-alpine` builder → `nginx:1.27-alpine` runtime). `frontend/nginx.conf` configures: SPA fallback to `index.html`, immutable 1-year cache on Vite's content-hashed assets, no-cache on the entry document, and explicit 404s on `/api/*` + `/oauth2/*` (the backend lives on a separate hostname; if a real backend request reaches this Nginx, something's misconfigured and we'd rather fail cleanly than fall through to the SPA shell).
 
+### Runtime config (`/config.js`)
+
+The same image deploys to every environment; environment-specific values (today: the backend's absolute URL) come from a `/config.js` written at container startup.
+
+- **`frontend/public/config.js`** (committed) ships a default with empty `apiBaseUrl`. Vite serves it verbatim in dev → the SPA uses relative URLs that go through the Vite proxy.
+- **`frontend/docker-entrypoint.d/40-generate-config-js.sh`** runs at container start (nginx's standard `/docker-entrypoint.d/` mechanism). It overwrites `/usr/share/nginx/html/config.js` from `$APP_API_BASE_URL`, with backslash + double-quote escaping so any value rides safely inside a JS string literal.
+- **`index.html`** loads `/config.js` as a classic (synchronous) script. The React bundle is a module script (deferred), so `window.__APP_CONFIG__` is always populated before bundle code runs — regardless of where Vite places either tag in the built HTML.
+- **`frontend/src/config.ts`** exports a typed `appConfig` (just `apiBaseUrl` for now). Strip-trailing-slash normalization lives here.
+- **`frontend/src/api/http.ts`** prepends `appConfig.apiBaseUrl` to leading-slash string URLs inside `requestJson`. Empty `apiBaseUrl` (dev) is a no-op. Absolute URLs, `Request` objects, and `URL` instances pass through untouched.
+
+To add a new runtime knob (say, a feature flag): extend `AppConfig` in `src/config.ts`, extend the heredoc in `40-generate-config-js.sh`, and document the new env var.
+
 ## Module-specific notes
 
 - **Vite proxy** in `vite.config.ts` forwards `/api/*`, `/oauth2/*`, and `/login/oauth2/*` to backend `localhost:8080`. Same-origin in the browser during dev — no CORS needed locally. Production is cross-origin under a shared parent domain; bearer tokens (not cookies) ride on every request, so no cross-origin cookie machinery is needed.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,6 +26,7 @@ LABEL org.opencontainers.image.source="https://github.com/cnau/tc-overwatch"
 LABEL org.opencontainers.image.description="tc-overwatch frontend (Nginx + static bundle)"
 
 COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --chmod=0755 frontend/docker-entrypoint.d/ /docker-entrypoint.d/
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 EXPOSE 80

--- a/frontend/docker-entrypoint.d/40-generate-config-js.sh
+++ b/frontend/docker-entrypoint.d/40-generate-config-js.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Generate /config.js from APP_API_BASE_URL before nginx starts. nginx:alpine
+# runs anything in /docker-entrypoint.d/ at container start. The SPA loads this
+# file synchronously (classic <script>) before the React bundle, so the value
+# is available to window.__APP_CONFIG__ on first render.
+#
+# Empty APP_API_BASE_URL → empty apiBaseUrl → SPA uses relative URLs. Useful
+# only when the SPA is reverse-proxied behind the backend's hostname.
+set -eu
+
+# Escape backslashes and double-quotes so any value can ride inside a double-
+# quoted JS string literal without breaking syntax.
+escaped=$(printf '%s' "${APP_API_BASE_URL:-}" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+cat > /usr/share/nginx/html/config.js <<EOF
+window.__APP_CONFIG__ = {
+  apiBaseUrl: "${escaped}",
+};
+EOF

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,8 @@
   </head>
   <body>
     <div id="root"></div>
+    <!-- Classic (non-module) script: runs synchronously, populates window.__APP_CONFIG__ before the bundle. -->
+    <script src="/config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/public/config.js
+++ b/frontend/public/config.js
@@ -1,0 +1,7 @@
+// Default runtime config (empty apiBaseUrl → SPA uses relative URLs, which
+// the Vite dev proxy handles). The production Docker image overwrites this
+// file at container start from $APP_API_BASE_URL — see
+// frontend/docker-entrypoint.d/40-generate-config-js.sh.
+window.__APP_CONFIG__ = {
+  apiBaseUrl: '',
+};

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,3 +1,5 @@
+import { appConfig } from '@/config'
+
 export class ApiError extends Error {
   readonly code: string
   readonly status: number
@@ -37,7 +39,7 @@ export async function requestJson<T>(input: RequestInfo | URL, init: RequestInit
   if (token && !headers.has('Authorization')) {
     headers.set('Authorization', `Bearer ${token}`)
   }
-  const res = await fetch(input, {
+  const res = await fetch(withBaseUrl(input), {
     ...init,
     headers,
   })
@@ -48,6 +50,16 @@ export async function requestJson<T>(input: RequestInfo | URL, init: RequestInit
 
   if (res.status === 204) return undefined as T
   return (await res.json()) as T
+}
+
+// Prepend the runtime apiBaseUrl to leading-slash string URLs. Absolute URLs,
+// Request objects, and URL instances pass through unchanged. Empty apiBaseUrl
+// (dev) leaves the relative path alone for the Vite proxy to forward.
+function withBaseUrl(input: RequestInfo | URL): RequestInfo | URL {
+  if (typeof input !== 'string') return input
+  if (!input.startsWith('/')) return input
+  if (!appConfig.apiBaseUrl) return input
+  return `${appConfig.apiBaseUrl}${input}`
 }
 
 async function parseError(res: Response): Promise<ApiError> {

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,20 @@
+// Runtime config read once at module load. The actual values come from
+// /public/config.js (dev) or the container-generated /config.js (prod).
+// index.html loads that script before the React bundle, so window.__APP_CONFIG__
+// is populated by the time this module runs.
+
+type AppConfig = {
+  apiBaseUrl: string
+}
+
+declare global {
+  interface Window {
+    __APP_CONFIG__?: AppConfig
+  }
+}
+
+export const appConfig: AppConfig = {
+  // Trailing slash stripped so callers can write `${apiBaseUrl}/api/...`
+  // without worrying about doubling up.
+  apiBaseUrl: (window.__APP_CONFIG__?.apiBaseUrl ?? '').replace(/\/$/, ''),
+}


### PR DESCRIPTION
## Summary

Follow-up to #102 ([`PR #71`'s exit note](https://github.com/cnau/tc-overwatch/pull/102)): the SPA needs a way to call `api.<domain>` cross-origin without baking the URL into the bundle at build time. Reach the same "one artifact, multiple deploys" model that server + migrate already follow.

Mechanism:

- `frontend/public/config.js` ships a default with empty `apiBaseUrl`; Vite serves it verbatim in dev, the SPA uses relative URLs, the Vite proxy handles `/api/*`.
- `frontend/docker-entrypoint.d/40-generate-config-js.sh` runs at container start (nginx's standard `/docker-entrypoint.d/` mechanism) and overwrites `/usr/share/nginx/html/config.js` from `$APP_API_BASE_URL`, with backslash + double-quote escaping.
- `index.html` loads `/config.js` as a **classic synchronous** script. The React bundle is a deferred module — `window.__APP_CONFIG__` is always populated before bundle code reads it regardless of where Vite places either tag in the built HTML.
- `src/config.ts` exposes a typed `appConfig` with trailing-slash normalization.
- `src/api/http.ts`'s `requestJson` prepends `apiBaseUrl` to leading-slash string URLs. Absolute URLs, `Request` objects, and `URL` instances pass through untouched.
- `.env.unraid.example` adds `APP_API_BASE_URL`.
- `docs/architecture.md` + `frontend/CLAUDE.md` pin the mechanism and the runtime-vs-build-time rationale.

## Test plan

- [x] `npm --prefix frontend run build` clean (Vite hoists the module script into `<head>`; deferred semantics still guarantee the classic `/config.js` runs first)
- [x] `npm --prefix frontend run lint` clean
- [x] Vite dev (`npm run dev` on :5173): `GET /config.js` returns the default with empty `apiBaseUrl`; both script tags present in index.html with correct ordering
- [x] Docker container with no env: `cat /usr/share/nginx/html/config.js` shows `apiBaseUrl: ""`
- [x] Docker container with `APP_API_BASE_URL=https://api.example.com`: `cat ...` shows the configured value
- [x] Tricky values (quote + backslash) are properly JS-escaped (`\"q\"\\back`)
- [ ] CI green on this PR
- [ ] After merge: `ghcr.io/cnau/tc-overwatch-frontend:main` picks up the entrypoint script + config.ts in the next build

🤖 Generated with [Claude Code](https://claude.com/claude-code)