### PR TITLE
Wire frontend service into docker-compose.unraid.yml

### DIFF
--- a/docker-compose.unraid.yml
+++ b/docker-compose.unraid.yml
@@ -11,9 +11,8 @@
 # strings. The .env file lives at /mnt/user/tco/.env with mode 0600, outside
 # the repo. See .env.unraid.example for the required keys.
 #
-# Frontend (Nginx + static bundle from GHCR) and cloudflared (Cloudflare
-# Tunnel connector) services land in later commits — blocked on the frontend
-# OCI image (#71) and Cloudflare Tunnel hostname registration (#74 / #75).
+# cloudflared (Cloudflare Tunnel connector) is still deferred — blocked on
+# tunnel hostname registration (#74) and the production OAuth client (#75).
 
 services:
   postgres:
@@ -66,6 +65,28 @@ services:
       - tco-net
     # Healthcheck deferred: the eclipse-temurin:23-jre base lacks curl/wget,
     # and nothing else in the stack currently depends_on backend's health.
+
+  frontend:
+    image: ghcr.io/cnau/tc-overwatch-frontend:main
+    container_name: tco-frontend
+    restart: unless-stopped
+    env_file:
+      - /mnt/user/tco/.env
+    environment:
+      # Fail-fast guard: the SPA needs an absolute backend URL baked into
+      # /config.js at container start (see frontend/docker-entrypoint.d/).
+      # Empty value = silently-broken cross-origin in the browser.
+      APP_API_BASE_URL: ${APP_API_BASE_URL:?missing — pass --env-file /mnt/user/tco/.env}
+    healthcheck:
+      # 127.0.0.1, not localhost: nginx listens IPv4-only and the container's
+      # localhost resolves to ::1 first.
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://127.0.0.1/ || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
+    networks:
+      - tco-net
 
 networks:
   tco-net:


### PR DESCRIPTION
## Summary

Adds the frontend service to `docker-compose.unraid.yml` now that the image (#71/#102) and runtime config (#103) are both shipped. Completes the Unraid stack shape from #72's original scope, modulo cloudflared (still blocked on #74 + #75).

- `image: ghcr.io/cnau/tc-overwatch-frontend:main`, `restart: unless-stopped`.
- `env_file: /mnt/user/tco/.env` — passes `APP_API_BASE_URL` into the container's runtime entrypoint, which writes `/config.js` for the SPA.
- `APP_API_BASE_URL` guarded with the same `${VAR:?missing — pass --env-file /mnt/user/tco/.env}` fail-fast syntax as `POSTGRES_DB` / `TCO_MIGRATE_PASSWORD`. Empty value would silently break cross-origin in the browser, which is worse than a clear parse-time error.
- Healthcheck via `wget --spider http://127.0.0.1/` — nginx listens IPv4-only and the container's `localhost` resolves to `::1` first (verified). Nothing `depends_on` the frontend yet, but cloudflared will once it lands.
- Updated header comment: `Frontend ... services land in later commits` → `cloudflared ... is still deferred`.

## Test plan

- [x] `docker compose -f docker-compose.unraid.yml --env-file <populated> config` resolves all interpolations cleanly
- [x] Missing `APP_API_BASE_URL` fails fast with the custom "missing — pass --env-file" error
- [x] Missing `--env-file` fails fast at the first `${VAR:?...}` (POSTGRES_DB), as before
- [x] Frontend container healthcheck command returns HEALTHY when run inside a running container
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)