### PR TITLE
Backend CORS allowlist for cross-origin SPA → API

### DIFF
--- a/server/src/main/kotlin/com/tcoverwatch/common/security/CorsConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/CorsConfig.kt
@@ -1,0 +1,37 @@
+package com.tcoverwatch.common.security
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+
+@ConfigurationProperties("cors")
+data class CorsProperties(
+    val allowedOrigins: List<String> = emptyList(),
+)
+
+// CORS only matters for the /api/** XHR surface — OAuth start/callback are
+// top-level navigations. Bearer tokens (no cookies) → no Allow-Credentials.
+@Configuration
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@EnableConfigurationProperties(CorsProperties::class)
+class CorsConfig {
+    @Bean
+    fun corsConfigurationSource(props: CorsProperties): CorsConfigurationSource {
+        val config =
+            CorsConfiguration().apply {
+                allowedOrigins = props.allowedOrigins
+                allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                allowedHeaders = listOf("Authorization", "Content-Type")
+                allowCredentials = false
+                maxAge = 3600L
+            }
+        return UrlBasedCorsConfigurationSource().apply {
+            registerCorsConfiguration("/api/**", config)
+        }
+    }
+}

--- a/server/src/main/kotlin/com/tcoverwatch/common/security/SecurityConfig.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/common/security/SecurityConfig.kt
@@ -25,6 +25,8 @@ class SecurityConfig {
         http
             // Bearer tokens have no ambient browser credential to forge — CSRF doesn't apply.
             .csrf(AbstractHttpConfigurer<*, *>::disable)
+            // Picks up the CorsConfigurationSource bean defined in CorsConfig.
+            .cors { }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {
                 it

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -23,3 +23,9 @@ auth:
   jwt:
     # Local-dev only. HS256 needs ≥32 bytes; this string isn't a real secret.
     secret: "tc-overwatch-local-dev-jwt-secret-do-not-use-in-prod"
+
+cors:
+  # The Vite proxy makes the SPA same-origin in dev, but a direct curl with
+  # `-H "Origin: http://localhost:5173"` will trigger CORS — allowlist it.
+  allowed-origins:
+    - http://localhost:5173

--- a/server/src/main/resources/application-unraid.yml
+++ b/server/src/main/resources/application-unraid.yml
@@ -15,3 +15,7 @@ auth:
 
 app:
   frontend-base-url: ${APP_FRONTEND_BASE_URL}
+
+cors:
+  allowed-origins:
+    - ${APP_FRONTEND_BASE_URL}


### PR DESCRIPTION
## Summary

Pre-pinned in \`docs/architecture.md\` § CORS; this lands the implementation. Allows the SPA at \`app.<domain>\` to call the backend at \`api.<domain>\` once the tunnel is live.

- **\`common/security/CorsConfig.kt\`** — \`CorsProperties\` binds \`cors.allowed-origins\`. \`CorsConfigurationSource\` bean registered for \`/api/**\`. \`allowCredentials = false\` (bearer tokens, no cookies). Allowed headers: \`Authorization\`, \`Content-Type\`. \`@ConditionalOnWebApplication(SERVLET)\` matches the scaffold pattern.
- **\`common/security/SecurityConfig.kt\`** — adds \`.cors {}\` to the main filter chain, which picks up the \`corsConfigurationSource\` bean by name.
- **\`application-local.yml\`** — allowlists \`http://localhost:5173\` (Vite dev origin; the proxy makes it rarely hit but a direct curl with \`-H "Origin: ..."\` will trigger CORS).
- **\`application-unraid.yml\`** — allowlists \`\${APP_FRONTEND_BASE_URL}\` (the Cloudflare Tunnel frontend hostname; for our deploy: \`https://app.tc-overwatch.net\`).

## Test plan

Verified locally with bootRun + curl:

- [x] Allowed origin (\`Origin: http://localhost:5173\`) on \`POST /api/ping\` → 200 + \`Access-Control-Allow-Origin: http://localhost:5173\`
- [x] Disallowed origin on \`POST /api/ping\` → 403 (Spring's CORS filter rejects fast)
- [x] Preflight \`OPTIONS\` from allowed origin → 200 + ACAO + ACAM + ACAH
- [x] Preflight from disallowed origin → 403
- [x] \`./gradlew :server:build :server:ktlintCheck\` clean
- [ ] CI green
- [ ] End-to-end (after the tunnel is live): SPA at \`https://app.tc-overwatch.net\` makes an API call to \`https://api.tc-overwatch.net/api/...\` and receives \`Access-Control-Allow-Origin: https://app.tc-overwatch.net\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)