### PR TITLE
Backend healthcheck: image-level HEALTHCHECK + cloudflared depends_on healthy

### DIFF
--- a/docker-compose.unraid.yml
+++ b/docker-compose.unraid.yml
@@ -67,8 +67,7 @@ services:
         condition: service_completed_successfully
     networks:
       - tco-net
-    # Healthcheck deferred: the eclipse-temurin:23-jre base lacks curl/wget,
-    # and nothing else in the stack currently depends_on backend's health.
+    # Healthcheck is declared in server/Dockerfile (image-level HEALTHCHECK).
 
   cloudflared:
     # To bump: docker pull cloudflare/cloudflared:<new-tag>; copy the printed digest here.
@@ -82,7 +81,7 @@ services:
       frontend:
         condition: service_healthy
       backend:
-        condition: service_started
+        condition: service_healthy
     networks:
       - tco-net
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,11 +13,24 @@ LABEL org.opencontainers.image.description="tc-overwatch backend"
 
 WORKDIR /app
 
+# wget is for the HEALTHCHECK below. --no-install-recommends keeps the image
+# lean; the apt lists are removed in the same layer to avoid carrying ~30MB
+# of package metadata into the final image.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd --system app && useradd --system --gid app --no-create-home app
 USER app:app
 
 COPY --chown=app:app server/build/libs/server-*-SNAPSHOT.jar /app/server.jar
 
 EXPOSE 8080
+
+# 127.0.0.1, not localhost — eclipse-temurin's localhost resolves to ::1 first
+# (same gotcha as nginx:alpine). Spring Actuator returns 200 only when every
+# component is UP, 503 otherwise — --spider's 200-only success matches that.
+HEALTHCHECK --interval=10s --timeout=3s --retries=12 --start-period=30s \
+    CMD wget --quiet --tries=1 --spider http://127.0.0.1:8080/actuator/health || exit 1
 
 ENTRYPOINT ["java", "-jar", "/app/server.jar"]


### PR DESCRIPTION
## Summary

Removes the "Healthcheck deferred" TODO from #105. Spring Actuator's \`/actuator/health\` is now exposed as a Docker healthcheck, and cloudflared waits for the backend to actually serve requests before sending traffic — eliminating the startup-window 502s.

- **\`server/Dockerfile\`** installs \`wget\` (apt-get \`--no-install-recommends\` + \`rm -rf /var/lib/apt/lists/*\` in the same layer to keep the image lean), and declares an image-level \`HEALTHCHECK\` hitting \`http://127.0.0.1:8080/actuator/health\`. Spring Actuator returns 200 only when every component is UP, 503 otherwise — \`wget --spider\`'s 200-only success matches that. Same \`127.0.0.1\`-not-\`localhost\` gotcha as nginx:alpine (Spring binds IPv4-only).
- **\`docker-compose.unraid.yml\`** cloudflared \`depends_on.backend.condition\` flips from \`service_started\` to \`service_healthy\`. The backend-side healthcheck-in-compose comment is dropped — image-level HEALTHCHECK is the single source of truth, compose inherits.

## Test plan

- [x] \`./gradlew :server:build :server:ktlintCheck\` clean
- [x] \`docker build -f server/Dockerfile .\` succeeds; \`docker image inspect\` shows the HEALTHCHECK with the right command + timing
- [x] \`wget --version\` runs inside the image
- [x] Backend container started against tco-postgres on the local bridge network transitions \`starting → healthy\` in ~7s
- [ ] CI green
- [ ] After merge: the next published \`tc-overwatch-server:main\` image carries the HEALTHCHECK; \`docker compose up\` on Unraid sees backend go healthy before cloudflared starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)