### PR TITLE
SignInCard: prepend apiBaseUrl to OAuth start link

### DIFF
--- a/frontend/src/components/SignInCard.tsx
+++ b/frontend/src/components/SignInCard.tsx
@@ -1,11 +1,16 @@
 import { Button, Card, Stack, Title } from '@mantine/core'
 
+import { appConfig } from '@/config'
+
 export default function SignInCard() {
+  // OAuth start is a top-level navigation, not a fetch — apiBaseUrl prepending
+  // can't ride through http.ts here, so we apply it inline. Empty apiBaseUrl
+  // (dev) leaves the path relative for the Vite proxy.
   return (
     <Card withBorder radius="md" p="lg">
       <Stack gap="md">
         <Title order={3}>Sign in</Title>
-        <Button component="a" href="/oauth2/authorization/google" variant="filled">
+        <Button component="a" href={`${appConfig.apiBaseUrl}/oauth2/authorization/google`} variant="filled">
           Sign in with Google
         </Button>
       </Stack>


### PR DESCRIPTION
## Summary

Fixes the 404 from the sign-in button on the deployed pilot. The OAuth start endpoint lives on the backend (\`api.<domain>\`), but the SPA's button used a relative href, which resolved against the frontend origin (\`app.<domain>/oauth2/authorization/google\`) → frontend Nginx → 404 (per the explicit \`/oauth2/\` 404 rule in nginx.conf, by design — better than falling through to the SPA shell).

Mirror what \`http.ts\` does for fetch() URLs: prepend \`appConfig.apiBaseUrl\` inline. Empty in dev → relative path → Vite proxy handles. Set in prod → \`https://api.tc-overwatch.net/oauth2/authorization/google\` → backend handles.

This was the only spot in the codebase still using a relative path to a backend URL (\`grep -rn 'href="/api\\|href="/oauth\\|href="/login'\` found one hit).

## Test plan

- [x] \`npm --prefix frontend run build\` + \`npm --prefix frontend run lint\` clean
- [ ] CI green
- [ ] After merge + \`docker compose pull frontend && up -d frontend\` on Unraid: clicking "Sign in with Google" navigates to \`https://api.tc-overwatch.net/oauth2/authorization/google\`, which redirects to Google's account picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)