### PR TITLE
Unraid: trust X-Forwarded-Proto for OAuth redirect URI (HTTPS)

### DIFF
--- a/server/src/main/resources/application-unraid.yml
+++ b/server/src/main/resources/application-unraid.yml
@@ -9,6 +9,14 @@ spring:
     password: ${TCO_APP_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
+# Cloudflare Tunnel terminates TLS at the edge and forwards plain HTTP to the
+# backend with X-Forwarded-Proto: https. NATIVE = Tomcat's RemoteIpValve trusts
+# X-Forwarded-* from upstream IPs (default trust list includes 172.16/12 — the
+# Docker bridge range cloudflared connects from). Without this, Spring builds
+# OAuth redirect_uri as http://... and Google rejects with redirect_uri_mismatch.
+server:
+  forward-headers-strategy: NATIVE
+
 auth:
   jwt:
     secret: ${AUTH_JWT_SECRET}


### PR DESCRIPTION
## Summary

Fixes \`Error 400: redirect_uri_mismatch\` on Google sign-in. Cloudflare Tunnel terminates TLS at the edge and proxies plain HTTP to the backend, with \`X-Forwarded-Proto: https\` on the request. Without telling Spring to trust that header, it sees \`request.getScheme() = "http"\` and builds the OAuth redirect URI as \`http://api.tc-overwatch.net/login/oauth2/code/google\` — which Google rejects because the registered URI is \`https://...\`.

\`server.forward-headers-strategy: NATIVE\` delegates to Tomcat's \`RemoteIpValve\`, which trusts \`X-Forwarded-*\` headers from the default trusted ranges (10/8, 172.16/12, 192.168/16, 127/8). cloudflared connects from inside \`tco-net\` (172.x bridge), so it's already in the trust list.

Unraid profile only — local dev hits the backend directly, no proxy in between.

## Test plan

- [x] \`./gradlew :server:build :server:ktlintCheck\` clean
- [ ] CI green
- [ ] After merge + \`docker compose pull backend && up -d backend\` on Unraid: clicking sign-in → Google's account picker (not redirect_uri_mismatch); after authenticating, redirect back to \`https://app.tc-overwatch.net/#token=...\` with a fragment-borne JWT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)