### PR TITLE
OAuthFailureHandler: log the exception

### DIFF
--- a/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/OAuthFailureHandler.kt
+++ b/server/src/main/kotlin/com/tcoverwatch/feature/auth/api/OAuthFailureHandler.kt
@@ -2,6 +2,7 @@ package com.tcoverwatch.feature.auth.api
 
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.web.authentication.AuthenticationFailureHandler
@@ -11,11 +12,16 @@ import org.springframework.stereotype.Component
 class OAuthFailureHandler(
     @Value("\${app.frontend-base-url}") private val frontendBaseUrl: String,
 ) : AuthenticationFailureHandler {
+    private val log = LoggerFactory.getLogger(OAuthFailureHandler::class.java)
+
     override fun onAuthenticationFailure(
         request: HttpServletRequest,
         response: HttpServletResponse,
         exception: AuthenticationException,
     ) {
+        // The SPA only sees a generic OAUTH_FAILED — the actual cause (bad
+        // client secret, JWK fetch error, clock skew, etc.) lives in this log.
+        log.warn("OAuth sign-in failed", exception)
         response.sendRedirect("$frontendBaseUrl/?error=OAUTH_FAILED")
     }
 }


### PR DESCRIPTION
## Summary

\`OAuthFailureHandler\` accepted the \`AuthenticationException\` argument but threw it away — only the generic \`?error=OAUTH_FAILED\` redirect made it to the SPA, and Spring Security's default OAuth2 logging is DEBUG, so the cause left no trail at INFO/WARN.

Log at WARN before redirecting. The SPA's error code stays generic on purpose (don't leak token-exchange details to the browser); backend operators get the full \`OAuth2AuthenticationException\` (or whatever subclass) including the OAuth error code in the message.

We hit this exact silent-failure on the pilot just now — sign-in failed, no clue why until we bumped \`org.springframework.security\` to DEBUG via env var. With this in place, WARN-level production logging catches it.

## Test plan

- [x] \`./gradlew :server:build :server:ktlintCheck\` clean
- [ ] CI green
- [ ] After merge + \`docker compose pull backend && up -d backend\` on the pilot: re-trigger a failing OAuth sign-in (e.g. clear cookies, click sign-in) → the backend log shows the full \`AuthenticationException\` with cause + message at WARN. The SPA still sees \`?error=OAUTH_FAILED\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)