### PR TITLE
Unraid: deploy continuously from CI via a self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,17 @@ on:
     branches: [main]
   pull_request:
 
-# Two parallel build pipelines per docs/architecture.md § CI/CD.
+# Build + deploy pipelines per docs/architecture.md § CI/CD.
 # build-and-push-* land the runtime images in GHCR on every main-branch
-# commit; deploy jobs (deploy-unraid-*, deploy-prod-*) pull from GHCR and
-# come later with the self-hosted runner setup.
+# commit; deploy-unraid-* pull those images onto the Unraid pilot box via the
+# self-hosted runner (docs/unraid-runner.md). deploy-prod-* come later.
+#
+# SECURITY — this repo is public, and the deploy jobs run on a self-hosted
+# runner sitting on a home network with the host Docker socket mounted. The
+# `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` guard on
+# every self-hosted job is what keeps a forked pull request from executing
+# attacker-authored steps there. Never drop that guard, and never add
+# `runs-on: [self-hosted, unraid]` to a job reachable from `pull_request`.
 
 jobs:
   build-server:
@@ -281,3 +288,120 @@ jobs:
           package-name: tc-overwatch-migrate
           package-type: container
           min-versions-to-keep: 5
+
+  # Unraid pilot deploy — backend half. Needs the migrate image too: the
+  # schema is applied by a one-shot migrate container built from the same
+  # commit, so an entity change and its changeset ship together or not at all.
+  #
+  # Serial by construction: migrate runs to completion, then the backend
+  # restarts. A failed migration fails the job before the new backend image is
+  # ever started, so the old container keeps serving instead of crash-looping
+  # against a half-migrated schema.
+  deploy-unraid-server:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build-and-push-server, build-and-push-migrate]
+    runs-on: [self-hosted, unraid]
+    permissions:
+      contents: read
+      packages: read
+    # Two deploys touching the same compose project at once corrupts the
+    # stack. Queue rather than cancel — a cancelled deploy could leave the
+    # migrate container half-applied.
+    concurrency:
+      group: deploy-unraid-server
+      cancel-in-progress: false
+    env:
+      # Every compose invocation needs the same -f and --env-file; spelling it
+      # once keeps the steps readable and copy-pasteable onto the box.
+      COMPOSE: docker compose -f docker-compose.unraid.yml --env-file /mnt/user/tco/.env
+    steps:
+      - uses: actions/checkout@v4
+
+      # Both services move to this commit's immutable tag. Without this the
+      # deploy would pull whatever `main` points at, which on a busy merge day
+      # is not necessarily the commit that triggered this run.
+      - name: Pin image tags to this commit
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          echo "TCO_SERVER_TAG=sha-${SHORT_SHA}" >> "$GITHUB_ENV"
+          echo "TCO_MIGRATE_TAG=sha-${SHORT_SHA}" >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull server + migrate images
+        run: $COMPOSE pull backend migrate
+
+      - name: Run DB migrations (one-shot container)
+        run: $COMPOSE run --rm migrate
+
+      # --no-deps because the previous step already satisfied them. Without it
+      # compose re-evaluates backend's `depends_on: migrate
+      # (service_completed_successfully)` and starts the migrate *service*
+      # container to satisfy it — a second, redundant Liquibase run whose
+      # failure would surface as a confusing backend-restart failure rather
+      # than as the migration step.
+      - name: Restart backend
+        run: $COMPOSE up -d --no-deps backend
+
+      - name: Wait for healthcheck
+        run: ./scripts/wait-for-healthy.sh tco-backend 180
+
+      - name: Smoke test
+        run: ./scripts/smoke.sh api
+
+      # The Actions log otherwise ends at "unhealthy" with no stack trace, and
+      # the container may already have been restarted by the time anyone SSHes in.
+      - name: Backend logs on failure
+        if: failure()
+        run: docker logs --tail 200 tco-backend || true
+
+  # Unraid pilot deploy — frontend half. Independent of the backend deploy by
+  # design: no `needs` on it, its own concurrency group, and a smoke test
+  # scoped to the app hostname. Either half can ship while the other is broken.
+  deploy-unraid-frontend:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build-and-push-frontend]
+    runs-on: [self-hosted, unraid]
+    permissions:
+      contents: read
+      packages: read
+    concurrency:
+      group: deploy-unraid-frontend
+      cancel-in-progress: false
+    env:
+      COMPOSE: docker compose -f docker-compose.unraid.yml --env-file /mnt/user/tco/.env
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pin image tag to this commit
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          echo "TCO_FRONTEND_TAG=sha-${SHORT_SHA}" >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull frontend image
+        run: $COMPOSE pull frontend
+
+      - name: Restart frontend
+        run: $COMPOSE up -d frontend
+
+      - name: Wait for healthcheck
+        run: ./scripts/wait-for-healthy.sh tco-frontend 60
+
+      - name: Smoke test
+        run: ./scripts/smoke.sh app
+
+      - name: Frontend logs on failure
+        if: failure()
+        run: docker logs --tail 200 tco-frontend || true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Automates the repetitive, time-consuming tasks that fill a real-estate transacti
 - **`docs/task-inventory.md`** — full task map with status flags (`[FOCUS]` / `[REVIEW]` / `[BACKLOG]` / etc.).
 - **`docs/glossary.md`** — project-specific vocabulary.
 - **`docs/architecture.md`** — implementation stack, security zones, deployment paths, CI/CD.
+- **`docs/unraid-runner.md`** — runbook for the self-hosted runner that deploys the pilot.
 
 ## Repo layout
 
@@ -31,9 +32,12 @@ Automates the repetitive, time-consuming tasks that fill a real-estate transacti
 ├── deploy/helm/tc-overwatch-server/  # Helm chart for GKE (future prod target)
 ├── scripts/db-init/                # Local Postgres init (roles + extensions)
 ├── scripts/db-init-unraid/         # Unraid Postgres init (env-driven passwords)
+├── scripts/wait-for-healthy.sh     # Deploy gate: block until a container is healthy
+├── scripts/smoke.sh                # Post-deploy checks against the public hostnames
 ├── docker-compose.local.yml        # Local Postgres for development
 ├── docker-compose.unraid.yml       # Unraid pilot deploy stack
-└── .github/workflows/ci.yml        # Build pipelines + GHCR image publish
+├── docker-compose.runner.yml       # Self-hosted GitHub Actions runner (Unraid)
+└── .github/workflows/ci.yml        # Build pipelines + GHCR publish + Unraid deploy
 ```
 
 ## Local development
@@ -58,7 +62,9 @@ The Vite dev server proxies `/api/*`, `/oauth2/*`, and `/login/oauth2/*` to `loc
 
 Pilot is live. The auth + multi-tenancy foundation ships: Google OAuth sign-in via Spring Security `oauth2Login()`, invitation-only signup gate, bearer JWT paradigm, RLS-enforced multi-tenancy backed by a three-role Postgres setup. CI builds and pushes all three images to GHCR (`tc-overwatch-server`, `-frontend`, `-migrate`) on every main commit, and the full Unraid stack — Postgres, migrate, backend, frontend, Cloudflare Tunnel — runs behind `tc-overwatch.net`; first end-to-end sign-in completed at the `pilot-live` tag.
 
-Deploys are still manual (`docker compose pull && up -d` on the host); CI/CD automation is epic #67. Real product features — email triage, transaction lifecycle, dashboard — have not started yet and land on top of this baseline. See `docs/task-inventory.md` and epic #17.
+Deploys are continuous: every commit to `main` builds the three images, then a self-hosted runner on the Unraid box pulls that commit's immutable tag, applies migrations in a one-shot container, restarts the affected service, and smoke-tests it through the public hostname. Backend and frontend deploy independently. See `docs/unraid-runner.md`.
+
+Real product features — email triage, transaction lifecycle, dashboard — have not started yet and land on top of this baseline. See `docs/task-inventory.md` and epic #17.
 
 ## License
 

--- a/docker-compose.runner.yml
+++ b/docker-compose.runner.yml
@@ -1,0 +1,50 @@
+# Self-hosted GitHub Actions runner for the Unraid pilot. Bring up via:
+#
+#   docker compose -f docker-compose.runner.yml \
+#     --env-file /mnt/user/tco/.env.runner up -d
+#
+# Full setup, including the PAT scopes and the security constraints that make
+# a self-hosted runner on a *public* repo safe, is in docs/unraid-runner.md.
+# Read that before running this.
+#
+# Deliberately its own compose project (`name:` below), not a service inside
+# docker-compose.unraid.yml: a deploy job runs `docker compose up -d backend`
+# against the app project, and a runner living in that project would be a
+# recreate candidate — the job would kill the container executing it.
+#
+# The runner makes only outbound calls to GitHub to claim jobs. No inbound
+# port, no firewall hole — the same posture as the Cloudflare Tunnel.
+
+name: tco-runner
+
+services:
+  runner:
+    # To bump: docker pull myoung34/github-runner:<new-tag>; copy the printed digest here.
+    image: myoung34/github-runner:2.336.0-ubuntu-noble@sha256:c803ddbc5b91961aabf3411c6336cb2c838cdaa2f917f76654c15a1948934817
+    container_name: tco-runner
+    restart: unless-stopped
+    env_file:
+      - /mnt/user/tco/.env.runner
+    environment:
+      REPO_URL: https://github.com/cnau/tc-overwatch
+      RUNNER_NAME: unraid
+      RUNNER_SCOPE: repo
+      # `self-hosted` is applied by GitHub automatically; this adds the second
+      # half of the `runs-on: [self-hosted, unraid]` selector.
+      LABELS: unraid
+      RUNNER_WORKDIR: /mnt/user/tco/runner/_work
+      # The image pins its own runner version and we pin its digest; letting it
+      # self-update would silently drift off the pinned artifact.
+      DISABLE_AUTO_UPDATE: "true"
+    volumes:
+      # Jobs drive the host's Docker daemon rather than nesting one. The runner
+      # is therefore as privileged as the host Docker socket — see the security
+      # section of docs/unraid-runner.md.
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Identical path on both sides, and it must be. Bind mounts declared in a
+      # compose file are resolved by the *host* daemon, not by the container
+      # issuing the command, so docker-compose.unraid.yml's relative
+      # ./scripts/db-init-unraid mount only resolves if the checkout sits at the
+      # same absolute path the host sees. Mount it anywhere else and compose
+      # silently bind-mounts an empty directory it created.
+      - /mnt/user/tco/runner/_work:/mnt/user/tco/runner/_work

--- a/docker-compose.unraid.yml
+++ b/docker-compose.unraid.yml
@@ -17,6 +17,24 @@
 #   app.<domain> → HTTP → frontend:80
 #   api.<domain> → HTTP → backend:8080
 # Routing config lives in the dashboard, not here.
+#
+# Image tags default to `main` — what a hand-run `up -d` on the box gets. The
+# deploy-unraid-* CI jobs override the one service they own with that commit's
+# immutable `sha-<short>` tag, so a deploy ships exactly the reviewed commit
+# and never races the moving `main` tag. Rollback is the same command with an
+# older SHA:
+#
+#   TCO_SERVER_TAG=sha-abc1234 docker compose -f docker-compose.unraid.yml \
+#     --env-file /mnt/user/tco/.env up -d backend
+#
+# Caveat of the defaults: a bare `up -d` (no tag vars) pulls every service back
+# to `main`, discarding a SHA-pinned rollback. Deploy one service at a time.
+
+# Pinned so the project identity doesn't depend on the directory compose runs
+# from. Without this, a CI checkout under the runner's workspace is a different
+# project than a hand-run from /mnt/user/tco/repo, and the second one collides
+# on the container_name values below instead of adopting the running stack.
+name: tco
 
 services:
   postgres:
@@ -37,7 +55,7 @@ services:
       - tco-net
 
   migrate:
-    image: ghcr.io/cnau/tc-overwatch-migrate:main
+    image: ghcr.io/cnau/tc-overwatch-migrate:${TCO_MIGRATE_TAG:-main}
     container_name: tco-migrate
     restart: "no"
     env_file:
@@ -53,7 +71,7 @@ services:
       - tco-net
 
   backend:
-    image: ghcr.io/cnau/tc-overwatch-server:main
+    image: ghcr.io/cnau/tc-overwatch-server:${TCO_SERVER_TAG:-main}
     container_name: tco-backend
     restart: unless-stopped
     env_file:
@@ -86,7 +104,7 @@ services:
       - tco-net
 
   frontend:
-    image: ghcr.io/cnau/tc-overwatch-frontend:main
+    image: ghcr.io/cnau/tc-overwatch-frontend:${TCO_FRONTEND_TAG:-main}
     container_name: tco-frontend
     restart: unless-stopped
     env_file:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -334,52 +334,25 @@ Server, migrate, and frontend deploys are independent. Any one can ship without 
 
 For the homelab path, the key trick is using a **GitHub Actions self-hosted runner** that lives on the Unraid box itself. The runner makes outbound calls to GitHub to fetch jobs — no inbound network exposure required. This is the same model as how Cloudflare Tunnel works for the app.
 
-Setup:
+Runner container: `myoung34/github-runner` (digest-pinned) via `docker-compose.runner.yml`, labeled `self-hosted, unraid`, registered to the repo with a fine-grained PAT scoped to this repo's Administration permission alone. It drives the host's Docker daemon through the mounted socket rather than nesting one. Setup procedure, PAT scopes, and operations are in **`docs/unraid-runner.md`**.
 
-- One `actions/runner` container (or `myoung34/github-runner` image) running on Unraid, labeled `self-hosted, unraid`, registered to the repo.
-- Mount the runner's working directory and the compose files onto the runner so it can `docker compose` against the host's Docker socket (or use Docker-in-Docker if isolation matters more).
-- Runner uses a fine-scoped PAT or GitHub App credentials with permission only to receive jobs for the repo.
-
-`deploy-unraid-server` job steps (backend):
-
-```yaml
-runs-on: [self-hosted, unraid]
-steps:
-  - name: Pull new server image
-    run: docker compose -f docker-compose.unraid.yml pull backend
-  - name: Run DB migrations (separate one-shot container)
-    run: docker compose -f docker-compose.unraid.yml run --rm migrate
-  - name: Restart backend
-    run: docker compose -f docker-compose.unraid.yml up -d backend
-  - name: Wait for healthcheck
-    run: ./scripts/wait-for-healthy.sh backend 60s
-  - name: Smoke test (HTTP ping)
-    run: ./scripts/smoke.sh
-```
-
-`deploy-unraid-frontend` job steps:
-
-```yaml
-runs-on: [self-hosted, unraid]
-steps:
-  - name: Pull new frontend image (nginx + static bundle)
-    run: docker compose -f docker-compose.unraid.yml pull frontend
-  - name: Restart frontend
-    run: docker compose -f docker-compose.unraid.yml up -d frontend
-  - name: Wait for healthcheck
-    run: ./scripts/wait-for-healthy.sh frontend 30s
-```
+`deploy-unraid-server` (backend + schema) and `deploy-unraid-frontend` live in `.github/workflows/ci.yml`. Their step sequence — pull → migrate → restart → `scripts/wait-for-healthy.sh` → `scripts/smoke.sh` — is the deploy contract; the workflow file is the authority on exact invocation.
 
 Important properties:
 
 - **Migrations run in a separate container** (`migrate` service in compose, using the `tco_migrate` DB role), not on app startup. Migration failures = clean deploy failure rather than silent crash loop.
 - **Backend starts only after migrations succeed.** Compose `depends_on` + the `migrate` service's `restart: "no"` + serial job steps enforce this.
-- **Frontend deploy never touches the backend, and vice versa.** Two independent pipelines, two independent Cloudflare Tunnel hostnames.
-- **No secrets in the CI workflow** — the runner has local access to the `.env` file on Unraid that docker-compose mounts. CI never sees DB credentials or OAuth secrets.
+- **Frontend deploy never touches the backend, and vice versa.** Two independent pipelines, two independent Cloudflare Tunnel hostnames — the frontend job carries no `needs` on the backend job, and each smoke-tests only its own hostname.
+- **No secrets in the CI workflow** — the runner has local access to the `.env` file on Unraid that docker-compose mounts. CI never sees DB credentials or OAuth secrets. `scripts/smoke.sh` greps that file for the two public base URLs rather than sourcing it, so the rest never enters the job environment.
+- **Deploys pin the commit's immutable `sha-<short>` tag**, injected as `TCO_{SERVER,MIGRATE,FRONTEND}_TAG` overrides on compose's `:main` defaults. A deploy therefore ships the exact commit that triggered it rather than whatever `main` points at by the time the job runs, and rollback is the same command with an older SHA.
+- **The compose project name is pinned (`name: tco`)** so a CI checkout under the runner's workspace and a hand-run from `/mnt/user/tco/repo` are the same project. Without it the second one collides on `container_name` instead of adopting the running stack.
+- **Self-hosted jobs are gated to `push` on `main`.** The repo is public and the runner holds the host Docker socket; that guard is what keeps a forked pull request off the box. It is a security boundary, not a cost optimization.
+
+Smoke tests hit the public Cloudflare hostnames rather than the containers on the docker network, so a green deploy also proves the tunnel and its hostname routing survived — the failure mode a container-local health check cannot see.
 
 ### Image tagging strategy
 
-- Every build tags the image with the **full git SHA** (immutable, traceable).
+- Every build tags the image with the **commit SHA** as `sha-<short>` (immutable, traceable). This is the tag the Unraid deploy jobs pin and the tag a rollback names.
 - `main` is a **moving tag** pointing at the latest successful main build.
 - Release versions (`v0.1.0`, `v1.0.0`) are immutable tags for prod deploys.
 - Unraid pilot tracks `main` (continuous deployment is fine — single user, fast feedback loop).

--- a/docs/unraid-runner.md
+++ b/docs/unraid-runner.md
@@ -48,9 +48,24 @@ repository, with one permission:
 | Repository → Administration | Read and write |
 
 That is what the GitHub API needs to mint runner registration tokens. It does
-not grant code push, package publish, or access to any other repo. Set an
-expiry and put a calendar reminder on it — an expired PAT shows up as a runner
-that silently stops claiming jobs.
+not grant code push, package publish, or access to any other repo — though
+Administration write can still change repo settings, webhooks, and deploy keys,
+which is why it gets an expiry rather than living on the box forever.
+
+**Use 90 days, and put a calendar reminder on it.** Note where an expired token
+does and doesn't hurt, because the failure is latent: the PAT is read only at
+*registration*, when the container's entrypoint exchanges it for a short-lived
+registration token. After that the runner polls GitHub with its own credentials,
+so steady-state job claiming never touches the PAT. Those credentials live in
+the container filesystem, which is not on a volume — a plain restart or an
+Unraid reboot keeps them, but any **recreate** (image bump, edit to
+`docker-compose.runner.yml`, `down`/`up`) re-registers and needs a live token.
+
+So an expired PAT is invisible for weeks and then surfaces the next time you
+touch the runner for an unrelated reason — as a runner that never comes back
+and jobs that queue. If tracking the expiry becomes a nuisance, swap the PAT
+for a GitHub App (`APP_ID` + `APP_PRIVATE_KEY`, both accepted by this image):
+installation tokens auto-renew, so the cliff disappears entirely.
 
 ### 2. Write the runner env file
 
@@ -168,7 +183,9 @@ skipped. The stack is still under its old project name.
 
 **Jobs sit queued forever** — no runner with both `self-hosted` and `unraid`
 labels is online. Check Repo Settings → Actions → Runners and `docker logs
-tco-runner`; an expired PAT looks exactly like this.
+tco-runner`. If this appeared right after recreating the runner container, and
+the log shows a registration failure rather than `Listening for Jobs`, the PAT
+expired — see step 1.
 
 **Postgres comes up with no roles, or `tco_app` doesn't exist** — the
 `./scripts/db-init-unraid` bind mount resolved to a path the host doesn't have,

--- a/docs/unraid-runner.md
+++ b/docs/unraid-runner.md
@@ -1,0 +1,165 @@
+# Self-hosted GitHub Actions runner (Unraid)
+
+Runbook for the runner that executes the `deploy-unraid-server` and
+`deploy-unraid-frontend` jobs in `.github/workflows/ci.yml`. Design rationale
+lives in `docs/architecture.md` § Unraid deploy: self-hosted runner; this file
+is the ops procedure.
+
+Everything here happens on the Unraid box. The steps are one-time unless marked
+otherwise.
+
+## Why a runner instead of a push-based deploy
+
+The Unraid box has no inbound network exposure, and adding one for CI would
+undo the reason Cloudflare Tunnel is in front of the app. The runner inverts
+the direction: it makes an outbound long-poll to GitHub, claims a job, and runs
+it locally. No port forward, no firewall hole, no credentials handed to GitHub.
+
+Because the runner is local, deploy jobs read `/mnt/user/tco/.env` straight off
+the host — **CI never sees a database password, the JWT secret, or the tunnel
+token.**
+
+## Security constraints (read before setup)
+
+This repo is **public**, and the runner mounts the host Docker socket. Those two
+facts together mean a job on this runner is effectively root on the Unraid box.
+Three things keep that safe, and all three are load-bearing:
+
+1. **Every self-hosted job is guarded by
+   `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`.** Only
+   code already merged to `main` reaches the box. A pull request from a fork
+   builds on GitHub-hosted runners and never touches this one. Removing that
+   guard is the single change that would turn any drive-by fork PR into remote
+   code execution on a home network.
+2. **Repo Settings → Actions → General → Fork pull request workflows** set to
+   *Require approval for all external contributors* (GitHub's default for public
+   repos). Defence in depth for the same attack.
+3. **The runner's PAT is scoped to this repo only** — see below.
+
+## Setup
+
+### 1. Create the personal access token
+
+A fine-grained PAT, resource owner `cnau`, **only** the `cnau/tc-overwatch`
+repository, with one permission:
+
+| Permission | Access |
+| --- | --- |
+| Repository → Administration | Read and write |
+
+That is what the GitHub API needs to mint runner registration tokens. It does
+not grant code push, package publish, or access to any other repo. Set an
+expiry and put a calendar reminder on it — an expired PAT shows up as a runner
+that silently stops claiming jobs.
+
+### 2. Write the runner env file
+
+Separate from the app's `.env` — the runner has no business being able to read
+DB passwords, and the app containers have no business reading a GitHub token:
+
+```bash
+install -m 0600 /dev/null /mnt/user/tco/.env.runner
+cat > /mnt/user/tco/.env.runner <<'EOF'
+ACCESS_TOKEN=github_pat_...
+EOF
+```
+
+### 3. Create the work directory
+
+```bash
+mkdir -p /mnt/user/tco/runner/_work
+```
+
+This path is bind-mounted into the runner **at the same absolute path** it has
+on the host, and that is not cosmetic. Bind mounts in a compose file are
+resolved by the host's Docker daemon, so `docker-compose.unraid.yml`'s relative
+`./scripts/db-init-unraid` mount is interpreted against the host filesystem. If
+the checkout lives at a path the host doesn't have, Docker creates an empty
+directory there and mounts *that* — a failure that surfaces much later as a
+Postgres container coming up with no roles provisioned.
+
+### 4. Migrate the app stack to the pinned compose project name
+
+`docker-compose.unraid.yml` now pins `name: tco`. The stack deployed by hand
+before this change took its project name from whatever directory it was run
+from, so the first CI deploy would try to create `tco-backend` while a
+container of that name already exists under the old project, and fail on the
+name collision.
+
+Check what the running stack calls itself:
+
+```bash
+docker inspect tco-backend --format '{{index .Config.Labels "com.docker.compose.project"}}'
+```
+
+If that prints anything other than `tco`, re-create the stack once under the
+pinned name (~30s of downtime; the Postgres data is a host bind mount at
+`/mnt/user/tco/postgres` and is not touched):
+
+```bash
+cd /mnt/user/tco/repo && git pull
+docker compose -p <old-name> -f docker-compose.unraid.yml --env-file /mnt/user/tco/.env down
+docker compose -f docker-compose.unraid.yml --env-file /mnt/user/tco/.env up -d
+```
+
+### 5. Start the runner
+
+```bash
+cd /mnt/user/tco/repo
+docker compose -f docker-compose.runner.yml --env-file /mnt/user/tco/.env.runner up -d
+docker logs -f tco-runner
+```
+
+Expect `√ Connected to GitHub` followed by `Listening for Jobs`. Confirm at
+Repo Settings → Actions → Runners: a runner named `unraid`, idle, labelled
+`self-hosted`, `Linux`, `X64`, `unraid`.
+
+### 6. Verify end to end
+
+Push a trivial commit to `main` (or re-run the latest CI run) and watch
+`deploy-unraid-server` and `deploy-unraid-frontend` claim the runner. A green
+run means the images pulled, migrations applied, containers reported healthy,
+and `scripts/smoke.sh` got the expected responses back through the tunnel.
+
+## Operations
+
+**Rollback.** Deploys pin the immutable `sha-<short>` tag, so rolling back is
+redeploying an older one. On the box:
+
+```bash
+cd /mnt/user/tco/repo
+TCO_SERVER_TAG=sha-abc1234 docker compose -f docker-compose.unraid.yml \
+  --env-file /mnt/user/tco/.env up -d backend
+```
+
+Same shape with `TCO_FRONTEND_TAG` / `frontend`. Note this does **not** roll the
+schema back — a rollback across a migration needs a forward-fixing changeset.
+Re-running CI on the older commit works too and is the more traceable option.
+
+Careful: a bare `docker compose up -d` with no tag variables set puts every
+service back on `:main` and quietly discards a pinned rollback. Deploy the one
+service you mean to.
+
+**Logs.** `docker logs -f tco-runner` for the runner; the failing deploy job's
+own log already carries the last 200 lines of the app container it restarted.
+
+**Upgrading the runner.** `docker-compose.runner.yml` pins an image digest.
+Pull the new tag, copy the printed digest into the file, commit, then
+`up -d` — same convention as `cloudflared` and the Liquibase base image.
+
+**Disk.** Every deploy leaves the previous image on the box. GHCR is pruned to
+5 versions per package by CI, but the Unraid side is not. Periodically:
+`docker image prune -a --filter "until=336h"`.
+
+**Deregistering.** `docker compose -f docker-compose.runner.yml down` stops the
+runner but leaves it registered; remove it from Repo Settings → Actions →
+Runners as well, otherwise jobs queue against a runner that is never coming
+back.
+
+## Fallback
+
+If the runner turns into a maintenance burden, `docs/architecture.md` records
+Watchtower as the substitute: it polls GHCR for the `main` tag and restarts
+changed containers. It costs the migration ordering, the health gate, and the
+smoke test — the whole point of this pipeline — so it's a retreat, not a
+refactor.

--- a/docs/unraid-runner.md
+++ b/docs/unraid-runner.md
@@ -156,6 +156,25 @@ runner but leaves it registered; remove it from Repo Settings → Actions →
 Runners as well, otherwise jobs queue against a runner that is never coming
 back.
 
+## Troubleshooting first-run failures
+
+**`permission denied while trying to connect to the Docker daemon socket`** — the runner
+process isn't in a group that can read `/var/run/docker.sock`. The image runs as
+root by default, which works; if `RUN_AS_ROOT=false` was set, either drop it or add
+the runner user to the socket's group.
+
+**`Conflict. The container name "/tco-backend" is already in use`** — step 4 was
+skipped. The stack is still under its old project name.
+
+**Jobs sit queued forever** — no runner with both `self-hosted` and `unraid`
+labels is online. Check Repo Settings → Actions → Runners and `docker logs
+tco-runner`; an expired PAT looks exactly like this.
+
+**Postgres comes up with no roles, or `tco_app` doesn't exist** — the
+`./scripts/db-init-unraid` bind mount resolved to a path the host doesn't have,
+so Docker mounted an empty directory. Re-check step 3: the work directory must
+be mounted at an identical path on both sides.
+
 ## Fallback
 
 If the runner turns into a maintenance burden, `docs/architecture.md` records

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Post-deploy smoke test. Called by the deploy-unraid-* CI jobs; safe to run
+# by hand from anywhere that can reach the public hostnames.
+#
+#   ./scripts/smoke.sh          # every check
+#   ./scripts/smoke.sh api      # backend only  (deploy-unraid-server)
+#   ./scripts/smoke.sh app      # frontend only (deploy-unraid-frontend)
+#
+# Scoped on purpose: a backend deploy must not fail because the frontend is
+# down, and vice versa — the two pipelines are independent by design (see
+# docs/architecture.md § Unraid deploy).
+#
+# These hit the *public* Cloudflare hostnames rather than the containers on the
+# docker network, so a green run also proves the tunnel and its hostname
+# routing survived the deploy — the failure mode a container-local curl misses.
+#
+# Base URLs resolve from, in order:
+#   1. SMOKE_API_BASE_URL / SMOKE_APP_BASE_URL
+#   2. APP_API_BASE_URL / APP_FRONTEND_BASE_URL in $TCO_ENV_FILE
+#      (default /mnt/user/tco/.env — the same file compose reads)
+# The env file is grepped for those two keys, never sourced: it also holds DB
+# passwords, the JWT secret, and the tunnel token, and sourcing it would put
+# all of them into the CI job's environment.
+
+set -euo pipefail
+
+TARGET="${1:-all}"
+ENV_FILE="${TCO_ENV_FILE:-/mnt/user/tco/.env}"
+
+case "$TARGET" in
+    api | app | all) ;;
+    *)
+        echo "usage: smoke.sh [api|app|all]" >&2
+        exit 2
+        ;;
+esac
+
+read_env() {
+    local key="$1" value
+    [[ -r "$ENV_FILE" ]] || return 0
+    # Last assignment wins, matching how compose reads the file.
+    value=$(grep -E "^${key}=" "$ENV_FILE" | tail -n1 | cut -d= -f2-)
+    value=${value%$'\r'}
+    value=${value%\"} && value=${value#\"}
+    value=${value%\'} && value=${value#\'}
+    printf '%s' "$value"
+}
+
+require_url() {
+    local name="$1" value="$2"
+    if [[ -z "$value" ]]; then
+        echo "::error::${name} is unset — pass SMOKE_${name%_BASE_URL}_BASE_URL or set it in ${ENV_FILE}" >&2
+        exit 2
+    fi
+    # Strip a trailing slash so path concatenation below never doubles up.
+    echo "${value%/}"
+}
+
+failures=0
+
+# Fetch $2 and assert the status code is $3 and the body matches $4 (a grep -F
+# pattern; pass '' to skip the body assertion). Prints a one-line verdict per
+# check so a failing deploy log says which assertion broke without a re-run.
+check() {
+    local label="$1" url="$2" want_status="$3" want_body="${4:-}"
+    local body status
+
+    body=$(mktemp)
+    # On a transport failure (DNS, TLS, timeout) curl writes its diagnostic to
+    # stderr, prints 000 as the code, and exits non-zero. Swallow the exit
+    # status so every check still runs and reports — one failing hostname
+    # shouldn't hide the state of the rest.
+    status=$(curl -sS --max-time 15 -o "$body" -w '%{http_code}' "$url" || true)
+    status=${status:-000}
+
+    if [[ "$status" != "$want_status" ]]; then
+        echo "FAIL  ${label}: expected HTTP ${want_status}, got ${status} (${url})"
+        head -c 500 "$body"
+        echo
+        rm -f "$body"
+        failures=$((failures + 1))
+        return
+    fi
+
+    if [[ -n "$want_body" ]] && ! grep -qF "$want_body" "$body"; then
+        echo "FAIL  ${label}: body did not contain '${want_body}' (${url})"
+        head -c 500 "$body"
+        echo
+        rm -f "$body"
+        failures=$((failures + 1))
+        return
+    fi
+
+    rm -f "$body"
+    echo "ok    ${label}"
+}
+
+if [[ "$TARGET" == "api" || "$TARGET" == "all" ]]; then
+    api_base=$(require_url API_BASE_URL "${SMOKE_API_BASE_URL:-$(read_env APP_API_BASE_URL)}")
+    echo "--- api @ ${api_base}"
+
+    # Actuator returns 200 only when every component is UP (503 otherwise), so
+    # the status code alone is the real assertion; the body check guards
+    # against a proxy that 200s an error page.
+    check "actuator health" "${api_base}/actuator/health" 200 '"status":"UP"'
+
+    # An unauthenticated /api/auth/me proves the security filter chain is wired
+    # and the @RestControllerAdvice envelope is intact. A 200 here would mean
+    # auth is bypassed — the failure worth catching before a user finds it.
+    check "unauthenticated /api/auth/me" "${api_base}/api/auth/me" 401 '"code":"UNAUTHENTICATED"'
+fi
+
+if [[ "$TARGET" == "app" || "$TARGET" == "all" ]]; then
+    app_base=$(require_url APP_BASE_URL "${SMOKE_APP_BASE_URL:-$(read_env APP_FRONTEND_BASE_URL)}")
+    api_base_for_config=$(read_env APP_API_BASE_URL)
+    echo "--- app @ ${app_base}"
+
+    check "index.html" "${app_base}/" 200 '<title>tc-overwatch</title>'
+
+    # /config.js is generated at container start from APP_API_BASE_URL. If the
+    # var went missing the SPA still serves a perfectly valid shell and then
+    # fails every API call in the browser — nginx returning 200 hides it, so
+    # assert the resolved backend URL is actually in there.
+    if [[ -n "${api_base_for_config}" ]]; then
+        check "config.js carries the API base URL" "${app_base}/config.js" 200 "${api_base_for_config%/}"
+    else
+        check "config.js" "${app_base}/config.js" 200 '__APP_CONFIG__'
+    fi
+fi
+
+if ((failures > 0)); then
+    echo "::error::smoke test failed (${failures} check(s))"
+    exit 1
+fi
+
+echo "smoke test passed"

--- a/scripts/wait-for-healthy.sh
+++ b/scripts/wait-for-healthy.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Block until a container reports healthy, or fail loudly.
+#
+#   ./scripts/wait-for-healthy.sh tco-backend 120
+#
+# Takes a container name (not a compose service name) so it needs no compose
+# context — no -f flag, no --env-file, no project-name guessing. The deploy
+# jobs already know the container names because docker-compose.unraid.yml
+# pins them.
+#
+# Exits non-zero on: unknown container, no healthcheck declared, `unhealthy`
+# status, or timeout. A container that exits mid-wait fails immediately rather
+# than burning the full timeout.
+
+set -euo pipefail
+
+CONTAINER="${1:?usage: wait-for-healthy.sh <container-name> [timeout-seconds]}"
+TIMEOUT="${2:-120}"
+
+if ! docker inspect "$CONTAINER" >/dev/null 2>&1; then
+    echo "::error::no such container: ${CONTAINER}"
+    exit 1
+fi
+
+# A container with no HEALTHCHECK reports an empty .State.Health — waiting on
+# it would spin until timeout and then report a confusing "never became
+# healthy". Say what's actually wrong instead.
+if [[ -z "$(docker inspect --format '{{if .State.Health}}yes{{end}}' "$CONTAINER")" ]]; then
+    echo "::error::${CONTAINER} declares no healthcheck — nothing to wait for"
+    exit 1
+fi
+
+echo "waiting up to ${TIMEOUT}s for ${CONTAINER} to report healthy..."
+
+for ((elapsed = 0; elapsed < TIMEOUT; elapsed += 2)); do
+    state=$(docker inspect --format '{{.State.Status}}' "$CONTAINER")
+    health=$(docker inspect --format '{{.State.Health.Status}}' "$CONTAINER")
+
+    case "${state}/${health}" in
+        running/healthy)
+            echo "${CONTAINER} healthy after ${elapsed}s"
+            exit 0
+            ;;
+        running/unhealthy)
+            # Docker retries a failing healthcheck before flipping to
+            # unhealthy, so this verdict is already the retried one.
+            echo "::error::${CONTAINER} is unhealthy"
+            docker inspect --format '{{range .State.Health.Log}}{{.Output}}{{end}}' "$CONTAINER" | tail -20
+            exit 1
+            ;;
+        running/starting) ;;
+        *)
+            echo "::error::${CONTAINER} left the running state (status=${state}, health=${health})"
+            exit 1
+            ;;
+    esac
+
+    sleep 2
+done
+
+echo "::error::${CONTAINER} did not become healthy within ${TIMEOUT}s"
+docker inspect --format '{{range .State.Health.Log}}{{.Output}}{{end}}' "$CONTAINER" | tail -20
+exit 1


### PR DESCRIPTION
## Summary

Closes the last four issues in epic #67: #73, #77, #78, #79. CI has been building three GHCR images per main-branch commit since the scaffold and then stopping there — getting them onto the pilot meant SSHing in and running `docker compose pull && up -d` by hand. What the pilot user was actually running was whatever someone last remembered to deploy, and the only verification was opening the site.

A self-hosted runner on the Unraid box closes the loop without opening the network. It long-polls GitHub outbound, claims jobs, and runs them locally — the same posture as the Cloudflare Tunnel in front of the app. Because it's local, the deploy jobs read `/mnt/user/tco/.env` off the host, so CI still never sees a DB password, the JWT secret, or the tunnel token.

Two independent deploy jobs, matching the two independent images and tunnel hostnames. `deploy-unraid-server` pulls, runs migrations in a one-shot container, restarts the backend, gates on the healthcheck, and smoke-tests the API. `deploy-unraid-frontend` does the same for the SPA with no `needs` on the backend job. Either half can ship while the other is broken.

Three things the obvious version of this gets wrong, all fixed here:

- **Deploys pin `sha-<short>`, not `:main`.** A job that pulls a moving tag deploys whatever that tag points at by the time the runner gets around to it, which on a busy merge day is not the commit under test. Compose keeps `:main` as the default so a hand-run on the box still works; CI overrides `TCO_{SERVER,MIGRATE,FRONTEND}_TAG` for the one service it owns. Rollback falls out of the same mechanism — redeploy an older SHA.
- **The compose project name is pinned (`name: tco`).** It was previously derived from the directory compose ran in, so a CI checkout under the runner's workspace would be a *different project* than the hand-run stack and would collide on every `container_name` rather than adopting it.
- **`up -d --no-deps backend`.** The migration step already satisfied the dependencies. Without `--no-deps`, compose re-evaluates `depends_on: migrate (service_completed_successfully)` and starts the migrate service a second time — so a migration failure surfaces as a confusing backend-restart failure instead of at the migration step.

`scripts/smoke.sh` hits the **public** Cloudflare hostnames rather than the containers on `tco-net`, so a green deploy also proves the tunnel and its hostname routing survived — a container-local curl passes happily while the tunnel is down. It greps `/mnt/user/tco/.env` for `APP_API_BASE_URL` and `APP_FRONTEND_BASE_URL` rather than sourcing it; sourcing would put every secret in that file into the job environment for the sake of two non-secret values. Checks are scoped (`api` / `app`) so a backend deploy cannot fail on a frontend outage.

`scripts/wait-for-healthy.sh` takes a container name rather than a compose service, so it needs no `-f`, no `--env-file`, and no project-name guessing. It fails distinctly on unknown container, no healthcheck declared, `unhealthy`, and exited-mid-wait — a bare timeout for all four is the version that's hard to debug from an Actions log.

**Security, stated in the workflow header and the runbook because it's load-bearing:** this repo is public and the runner mounts the host Docker socket, which makes a job on it effectively root on a home network. The `github.event_name == 'push' && github.ref == 'refs/heads/main'` guard on both deploy jobs is what keeps a forked pull request from executing attacker-authored steps there. It's a security boundary, not a cost optimization — hence the comment telling the next session not to remove it.

### Sequencing — this needs work on the box before merge

`docs/unraid-runner.md` is the runbook, and steps 4 and 5 have to happen on Unraid:

1. **Step 4 re-creates the stack once under the pinned project name** (`docker compose -p <old> ... down` then `up -d`). ~30s of downtime; the Postgres data is a host bind mount at `/mnt/user/tco/postgres` and isn't touched. Without it the first CI deploy fails on `Conflict. The container name "/tco-backend" is already in use`.
2. **Step 5 registers the runner.** Until it exists, `runs-on: [self-hosted, unraid]` has nothing to claim it, so the deploy jobs on the merge commit will sit queued (GitHub gives up after ~24h). Best order is: do steps 1–5 on the box against this branch, then merge.

The README's Status section is written as though the runner is already up, which becomes true at merge given that order.

### Not in scope

- **Automatic rollback.** A failed smoke test fails the deploy and leaves the new container running; recovery is redeploying an older SHA, per #79's stated v0 story. A traffic-flipping blue/green isn't worth it for one pilot user.
- **Schema rollback.** Image rollback doesn't undo a migration — crossing one needs a forward-fixing changeset. Called out in the runbook rather than pretended away.
- **Image GC on the box.** GHCR is pruned to 5 versions per package by CI; the Unraid side accumulates. Left as a periodic manual `docker image prune` in the runbook rather than automated, because an automatic `prune -a` on a homelab box is a bad thing to get wrong unattended.
- `deploy-prod-*` — still deliberately later, per `docs/architecture.md` § GCP deploy.

## Test plan

- [x] `scripts/smoke.sh` green against the live pilot on all four checks (actuator health, unauthenticated `/api/auth/me` → 401 `UNAUTHENTICATED`, index title, `config.js` carrying the API base URL)
- [x] `scripts/smoke.sh` exits non-zero with a per-check verdict for an unreachable host; exits 2 for a missing env file and for a bad target argument; tolerates a trailing slash on the base URL
- [x] `scripts/wait-for-healthy.sh` correct on all five paths: healthy, `unhealthy`, no healthcheck declared, unknown container, container exits mid-wait
- [x] `docker compose -f docker-compose.unraid.yml config` renders project `tco`, `:main` by default, and `sha-abc1234` with the tag vars set
- [x] `docker-compose.runner.yml` renders; `ci.yml` parses and both deploy jobs carry the `push` + `main` guard
- [x] CI green (`api-type-drift` failed once on a transient Maven Central blip — all three `ADD --checksum` fetches reported the same actual digest for three different JARs, i.e. one non-JAR body; the pins were re-verified against Maven Central and match, and the re-run is green)
- [ ] On the box, runbook steps 1–5: stack re-creates under project `tco` (`docker inspect tco-backend --format '{{index .Config.Labels "com.docker.compose.project"}}'` → `tco`), runner shows as idle under Settings → Actions → Runners with labels `self-hosted, unraid`
- [ ] After merge: `deploy-unraid-server` and `deploy-unraid-frontend` both claim the runner and go green; `docker inspect tco-backend --format '{{.Config.Image}}'` shows `sha-<merge commit>`, not `:main`; `https://app.tc-overwatch.net` still signs in end to end
- [ ] Negative check: push a commit whose migration is intentionally broken → `deploy-unraid-server` fails at the migration step with the old backend container still serving

Closes #73, closes #77, closes #78, closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
