### PR TITLE
Unraid runner: mount the app .env so compose can read it

### DIFF
--- a/docker-compose.runner.yml
+++ b/docker-compose.runner.yml
@@ -48,3 +48,18 @@ services:
       # same absolute path the host sees. Mount it anywhere else and compose
       # silently bind-mounts an empty directory it created.
       - /mnt/user/tco/runner/_work:/mnt/user/tco/runner/_work
+      # The app stack's .env, read-only. Easy to assume this is unnecessary
+      # because the *containers* it configures run on the host — but `--env-file`
+      # and the `env_file:` service directives are resolved by the compose
+      # *client*, which is this container. Without it every compose command in a
+      # deploy job dies with `couldn't find env file: /mnt/user/tco/.env`, before
+      # it ever reaches the daemon. scripts/smoke.sh reads the same file for the
+      # two public base URLs.
+      #
+      # This does put the pilot's secrets inside the runner's filesystem, which
+      # is the arrangement docs/architecture.md § Unraid deploy already assumes
+      # ("the runner has local access to the .env file on Unraid"). It grants a
+      # job nothing it couldn't already take: the Docker socket above is
+      # root-equivalent on the host. The boundary that matters stays the
+      # push-on-main guard in ci.yml, not this mount.
+      - /mnt/user/tco/.env:/mnt/user/tco/.env:ro

--- a/docs/unraid-runner.md
+++ b/docs/unraid-runner.md
@@ -93,6 +93,20 @@ the checkout lives at a path the host doesn't have, Docker creates an empty
 directory there and mounts *that* — a failure that surfaces much later as a
 Postgres container coming up with no roles provisioned.
 
+The runner also mounts `/mnt/user/tco/.env` read-only, which exists already from
+the app stack. Two different rules are at work and it's worth keeping them
+apart, because assuming one covers the other is what makes this fail:
+
+| Read by | Resolved against | Consequence |
+| --- | --- | --- |
+| Docker daemon — `volumes:` in `docker-compose.unraid.yml` | the **host** filesystem | paths must match what the host sees |
+| compose **client** — `--env-file`, `env_file:`, and anything a job's shell opens | the **runner container's** filesystem | the file must be mounted in |
+
+`--env-file` looks like daemon business because it configures containers that
+run on the host, but compose parses it client-side before it talks to the
+daemon at all. Miss the mount and every deploy job dies at its first compose
+command with `couldn't find env file: /mnt/user/tco/.env`.
+
 ### 4. Migrate the app stack to the pinned compose project name
 
 `docker-compose.unraid.yml` now pins `name: tco`. The stack deployed by hand
@@ -177,6 +191,11 @@ back.
 process isn't in a group that can read `/var/run/docker.sock`. The image runs as
 root by default, which works; if `RUN_AS_ROOT=false` was set, either drop it or add
 the runner user to the socket's group.
+
+**`couldn't find env file: /mnt/user/tco/.env`** — the runner container lacks
+the read-only `.env` mount, or predates it. Recreate it:
+`docker compose -f docker-compose.runner.yml --env-file /mnt/user/tco/.env.runner up -d --force-recreate`.
+A recreate re-registers the runner, so the PAT has to still be valid.
 
 **`Conflict. The container name "/tco-backend" is already in use`** — step 4 was
 skipped. The stack is still under its old project name.


### PR DESCRIPTION
## Summary

Fixes `couldn't find env file: /mnt/user/tco/.env`, which failed `deploy-unraid-frontend` on the #114 merge commit at its first compose command. `deploy-unraid-server` would have failed identically.

`docker-compose.runner.yml` mounted the work directory at a matching host path but not the `.env`, on the reasoning that bind mounts are resolved by the host daemon so the runner container doesn't need the paths itself. That reasoning is correct and doesn't cover this case: `--env-file` and the `env_file:` service directives are parsed by the compose **client** — the runner container — before it opens a connection to the daemon at all. The file *configures containers that run on the host*, which is what makes it look like the daemon's business. `scripts/smoke.sh` reads the same path for the two public base URLs, so the job would have failed at the next step regardless.

Mounted read-only.

**This doesn't widen the runner's access, despite reading like it does.** It's the arrangement `docs/architecture.md` § Unraid deploy already assumes — *"the runner has local access to the `.env` file on Unraid that docker-compose mounts"* — and the runner already holds the host Docker socket, which is root-equivalent: a job that can reach the socket can read that file with or without this mount. Nothing moves into GitHub Secrets or the workflow, so "CI never sees DB credentials" still holds in the sense that matters. The boundary doing the real work remains the push-on-main guard in `ci.yml`.

The runbook now presents the two resolution rules as a table — daemon-resolved (`volumes:`) vs client-resolved (`--env-file`, `env_file:`, anything a job's shell opens) — instead of explaining only the host-path one. Collapsing the two is precisely the mistake this fixes. The error string is in Troubleshooting too.

### Applying it

Needs the runner container recreated, which re-registers the runner and so needs the PAT to still be valid:

```bash
cd /mnt/user/tco/repo && git pull
docker compose -f docker-compose.runner.yml --env-file /mnt/user/tco/.env.runner up -d --force-recreate
```

Then re-run the failed jobs on the merge commit.

## Test plan

- [x] `docker compose -f docker-compose.runner.yml config` renders all three mounts, with `read_only: true` on the `.env`
- [ ] Runner recreated on the box, comes back to `Listening for Jobs`
- [ ] Re-run of `deploy-unraid-frontend` on the merge commit goes green through pull → restart → healthcheck → smoke
- [ ] `deploy-unraid-server` green; `docker inspect tco-backend --format '{{.Config.Image}}'` shows `:sha-<merge commit>` rather than `:main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
