### PR TITLE
Verify the deploy pipeline's migration-failure path (temporary)

### DIFF
--- a/server/src/main/resources/db/changelog/changelog-001.groovy
+++ b/server/src/main/resources/db/changelog/changelog-001.groovy
@@ -168,4 +168,20 @@ databaseChangeLog {
             dropTable(tableName: 'invitation')
         }
     }
+
+    // TEMPORARY — reverted immediately after the deploy pipeline observes it.
+    // Verifies the property claimed in docs/architecture.md § Unraid deploy:
+    // a migration failure fails the deploy at the migration step and leaves the
+    // running backend untouched, rather than restarting it against a schema it
+    // can't validate against.
+    //
+    // Deliberately atomic: ALTER TABLE on a missing relation errors before it
+    // changes anything, Postgres DDL is transactional, and Liquibase runs each
+    // changeset in its own transaction — so this applies nothing, records no
+    // row in DATABASECHANGELOG, and leaves no trace once the file is reverted.
+    changeSet(id: 'verify-deploy-migration-failure-path', author: 'Christian Nau') {
+        comment 'TEMPORARY deploy-pipeline verification. Fails on purpose. Revert immediately.'
+
+        sql "ALTER TABLE tco.relation_that_does_not_exist ADD COLUMN never_created TEXT;"
+    }
 }


### PR DESCRIPTION
## Summary

**Temporary — reverted immediately after the pipeline observes it. Do not leave on `main`.**

`docs/architecture.md` § Unraid deploy claims that running migrations in a separate one-shot container means *"migration failures = clean deploy failure rather than silent crash loop"*, and that *"the backend starts only after migrations succeed."* Nothing has exercised that. The four green deploys so far all carried a no-op migration, so the interesting branch of the deploy job has never executed.

This adds a changeset that fails on purpose. Expected: `deploy-unraid-server` fails at **Run DB migrations (one-shot container)**, skips **Restart backend**, and the pilot keeps serving the previous image throughout.

**The failure is chosen to be atomic, not merely broken.** `ALTER TABLE` on a missing relation errors before it changes anything, Postgres DDL is transactional, and Liquibase runs each changeset in its own transaction. Verified against a throwaway Postgres carrying the same role-init script:

- migrate exits `1`
- no row for the changeset in `DATABASECHANGELOG`
- `information_schema.columns` has zero rows named `never_created`

That's what makes reverting safe: no checksum is ever recorded, so the revert doesn't collide with the never-modify-a-committed-changeset rule in `CLAUDE.md`.

### Blast radius

- **The pilot database is not modified.** Nothing applies. On the pilot the six existing changesets are already `EXECUTED`, so the run is five no-ops and then the failure.
- **The live site keeps serving** — that's the property under test, not a side effect.
- **One real side effect:** while this is on `main`, `ghcr.io/cnau/tc-overwatch-migrate:main` points at an image containing the broken changelog. A *manual* `docker compose up -d` on the box during that window would attempt the same migration and fail the same way — no damage, but don't hand-deploy until the revert lands.
- `api-type-drift` is **expected to fail** here; it applies migrations against a fresh Postgres. Catching this pre-merge is that gate doing its job, and is itself worth seeing.

## Test plan

- [x] Throwaway Postgres + the real `migrate` image: exit 1, no `DATABASECHANGELOG` row, no schema trace
- [ ] `api-type-drift` fails on the migration (pre-merge gate works)
- [ ] `deploy-unraid-server` fails at **Run DB migrations**; **Restart backend**, **Wait for healthcheck** and **Smoke test** all show `skipped`
- [ ] `scripts/smoke.sh` still green against the live pilot *during* the failed deploy — old backend serving
- [ ] `deploy-unraid-frontend` unaffected and green (the two halves are independent)
- [ ] Revert merged, next `deploy-unraid-server` green, backend back on a fresh SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
