### PR TITLE
Revert the migration-failure-path verification changeset

### DIFF
--- a/server/src/main/resources/db/changelog/changelog-001.groovy
+++ b/server/src/main/resources/db/changelog/changelog-001.groovy
@@ -168,20 +168,4 @@ databaseChangeLog {
             dropTable(tableName: 'invitation')
         }
     }
-
-    // TEMPORARY — reverted immediately after the deploy pipeline observes it.
-    // Verifies the property claimed in docs/architecture.md § Unraid deploy:
-    // a migration failure fails the deploy at the migration step and leaves the
-    // running backend untouched, rather than restarting it against a schema it
-    // can't validate against.
-    //
-    // Deliberately atomic: ALTER TABLE on a missing relation errors before it
-    // changes anything, Postgres DDL is transactional, and Liquibase runs each
-    // changeset in its own transaction — so this applies nothing, records no
-    // row in DATABASECHANGELOG, and leaves no trace once the file is reverted.
-    changeSet(id: 'verify-deploy-migration-failure-path', author: 'Christian Nau') {
-        comment 'TEMPORARY deploy-pipeline verification. Fails on purpose. Revert immediately.'
-
-        sql "ALTER TABLE tco.relation_that_does_not_exist ADD COLUMN never_created TEXT;"
-    }
 }


### PR DESCRIPTION
## Summary

Reverts #116 now that the pipeline has demonstrated the behaviour it was testing. Restores `changelog-001.groovy` to its pre-#116 state.

Safe to revert rather than fix forward because **the changeset never executed**. It failed atomically, so Liquibase recorded no row in `DATABASECHANGELOG` and no checksum exists that removing the file could contradict — which is what keeps this clear of the never-modify-a-committed-changeset rule in `CLAUDE.md`. The pilot schema is byte-for-byte what it was before #116.

Merging this also clears the one real side effect of #116: `ghcr.io/cnau/tc-overwatch-migrate:main` currently points at an image containing the broken changelog.

## Test plan

- [ ] `api-type-drift` green again
- [ ] `deploy-unraid-server` green through migrate → restart → healthcheck → smoke
- [ ] Backend back on a fresh `sha-<merge commit>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)