### PR TITLE
Add an under-construction banner to the sign-in card

### DIFF
--- a/frontend/src/components/SignInCard.tsx
+++ b/frontend/src/components/SignInCard.tsx
@@ -1,5 +1,6 @@
 import { Button, Card, Stack, Title } from '@mantine/core'
 
+import UnderConstructionBanner from '@/components/UnderConstructionBanner'
 import { appConfig } from '@/config'
 
 export default function SignInCard() {
@@ -9,6 +10,7 @@ export default function SignInCard() {
   return (
     <Card withBorder radius="md" p="lg">
       <Stack gap="md">
+        <UnderConstructionBanner />
         <Title order={3}>Sign in</Title>
         <Button component="a" href={`${appConfig.apiBaseUrl}/oauth2/authorization/google`} variant="filled">
           Sign in with Google

--- a/frontend/src/components/UnderConstructionBanner.module.css
+++ b/frontend/src/components/UnderConstructionBanner.module.css
@@ -1,0 +1,69 @@
+.banner {
+  overflow: hidden;
+  border: rem(2px) solid #111;
+  border-radius: var(--mantine-radius-md);
+}
+
+.stripes {
+  height: rem(12px);
+  background-image: repeating-linear-gradient(45deg, #111 0 rem(10px), #f5c518 rem(10px) rem(20px));
+  animation: crawl 1.4s linear infinite;
+}
+
+/* 45deg stripes with a 20px period repeat every 20*sqrt(2) along x. */
+@keyframes crawl {
+  to {
+    background-position: rem(28.284px) 0;
+  }
+}
+
+.plaque {
+  padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
+  background-color: #111;
+}
+
+.sign {
+  width: rem(30px);
+  height: rem(27px);
+  flex-shrink: 0;
+}
+
+.arm {
+  transform-box: view-box;
+  transform-origin: rem(15px) rem(20px);
+  animation: dig 900ms ease-in-out infinite;
+}
+
+@keyframes dig {
+  0%,
+  100% {
+    transform: rotate(-20deg);
+  }
+
+  50% {
+    transform: rotate(12deg);
+  }
+}
+
+.text {
+  color: #f5c518;
+  font-weight: 800;
+  font-size: var(--mantine-font-size-sm);
+  letter-spacing: rem(2px);
+  text-transform: uppercase;
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  50% {
+    opacity: 0.55;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stripes,
+  .arm,
+  .text {
+    animation: none;
+  }
+}

--- a/frontend/src/components/UnderConstructionBanner.tsx
+++ b/frontend/src/components/UnderConstructionBanner.tsx
@@ -1,0 +1,25 @@
+import { Group, Text } from '@mantine/core'
+
+import classes from './UnderConstructionBanner.module.css'
+
+export default function UnderConstructionBanner() {
+  return (
+    <div className={classes.banner}>
+      <div className={classes.stripes} />
+      <Group className={classes.plaque} gap="sm" justify="center" wrap="nowrap">
+        <svg className={classes.sign} viewBox="0 0 40 36" aria-hidden="true" focusable="false">
+          <path d="M20 2 L38 33 H2 Z" fill="#f5c518" stroke="#111" strokeWidth="3" strokeLinejoin="round" />
+          <circle cx="15" cy="15" r="2.6" fill="#111" />
+          <path d="M15 18 v6" stroke="#111" strokeWidth="2.4" strokeLinecap="round" />
+          <path d="M15 24 l-3.5 5 M15 24 l4.5 4.5" stroke="#111" strokeWidth="2.2" strokeLinecap="round" />
+          <g className={classes.arm}>
+            <path d="M15 20 l8 3.5" stroke="#111" strokeWidth="2.2" strokeLinecap="round" />
+            <path d="M22 22 l6 2.5 l-2 4.5 l-6 -2.5 z" fill="#111" />
+          </g>
+        </svg>
+        <Text className={classes.text}>Under construction</Text>
+      </Group>
+      <div className={classes.stripes} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

The pilot TC can reach `app.tc-overwatch.net` and sign in, but everything behind the login is still the scaffold's ping card. Nothing on the way in said so, which invites the reasonable assumption that a working product is on the other side. This says it before the click.

**It's an inline animated SVG plus a CSS module, not the literal `.gif` the genre calls for.** A real GIF would be the repo's first binary asset and, if sourced from the era, someone else's copyright. It would also be a second request against an `nginx.conf` that deliberately serves nothing but the SPA. The SVG stays crisp on retina, scales with `--mantine-scale` like every other dimension in the app, and — the part a GIF genuinely cannot do — honours `prefers-reduced-motion`: all three animations stop for users who ask for that.

The look is unchanged by that choice: diagonal yellow/black hazard stripes crawling above and below, a triangular digging-worker sign with a swinging arm, and letterspaced yellow caps on black.

Placed inside `SignInCard` rather than `App`, so it's scoped to the signed-out view and disappears on sign-in instead of following the user into the app.

**Deliberately calmer than the genre:** the text pulses rather than hard-blinks and the stripes crawl at 1.4s. Easy to make properly obnoxious if that's the goal.

No new dependency, no `package.json` change, no backend contact — so `api-type-drift` is untouched.

## Test plan

- [x] `npm --prefix frontend run build` clean (tsc + vite)
- [x] `npm --prefix frontend run lint` clean
- [x] Compiled CSS verified: `rem()` resolved to `calc(… * var(--mantine-scale))`, keyframes hashed and correctly referenced by the CSS-module class names
- [x] Rendered in the Vite dev server — stripes, digging sign, and pulse all animating, banner sits between the session alert and the Sign in heading
- [ ] CI green
- [ ] After merge: `deploy-unraid-frontend` green, and the banner is visible signed-out at `https://app.tc-overwatch.net` — and gone after signing in

🤖 Generated with [Claude Code](https://claude.com/claude-code)