### PR TITLE
Publish local Postgres on 55432 instead of 5432

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -17,7 +17,13 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres_local_password
     ports:
-      - "5432:5432"
+      # 55432 on the host, not 5432. A work kubefwd session forwarding a
+      # Postgres service onto loopback aliases intermittently takes 5432, and
+      # this container then fails to start with "address already in use" —
+      # at unpredictable times, which is worse to diagnose than always.
+      # Container-internal traffic (the migrate service below, and anything on
+      # tco-net) still uses 5432; only the published host port moves.
+      - "55432:5432"
     volumes:
       # Postgres 18+ stores data under /var/lib/postgresql/<major>/docker; mount the parent.
       # See https://github.com/docker-library/postgres/pull/1259.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,13 +196,13 @@ Upgrade path: Temporal (durable workflows) or Cloud Tasks if/when one of: workfl
 Single repo runs locally with:
 
 ```
-docker compose up -d postgres        # Postgres 18 container, bound to localhost:5432
+docker compose up -d postgres        # Postgres 18 container, bound to localhost:55432
 ./gradlew bootRun                    # Spring Boot dev server on :8080
 cd frontend && npm run dev           # Vite dev server on :5173
 ```
 
 - A separate Google Cloud OAuth client is used for local dev with `http://localhost:8080/login/oauth2/code/google` as the authorized redirect URI (Spring Security's default callback path; the backend is the redirect target, not the SPA — the SPA then receives the minted JWT via fragment). The OAuth client *secret* never lives in `application-local.yml` (which is checked in) — it lives at `~/projects/tc-overwatch-secrets/local.env` (sibling to the repo, outside any path git can touch). IntelliJ run configs load it via the EnvFile plugin (see `.run/backend.run.xml`); CLI invocations source it manually before `./gradlew :server:bootRun`. Env var names: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`.
-- `docker-compose.local.yml` includes Postgres (and the role-init script under `scripts/db-init/`).
+- `docker-compose.local.yml` includes Postgres (and the role-init script under `scripts/db-init/`). It publishes **55432**, not 5432: a work `kubefwd` session forwarding a Postgres service onto loopback aliases intermittently holds 5432, and the container then fails to start. Only the published host port moves — container-to-container traffic inside the compose network still uses 5432.
 - Background jobs run in-process during local dev (no separate worker container).
 
 ## Deployment

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -3,7 +3,7 @@
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/tco
+    url: jdbc:postgresql://localhost:55432/tco
     username: tco_app
     password: tco_app_local_password
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## Summary

The local compose stack intermittently refuses to start with `bind: address already in use`. The cause is off-repo: a work `kubefwd svc -n hero` session forwards that namespace's services onto sequential loopback aliases (`127.1.27.1`, `.2`, …), and three of them are Postgres on 5432. While kubefwd is up, publishing 5432 can fail; when it isn't, everything works — so it's intermittent, and the error names a port rather than a cause. That's a rediagnosis every time it recurs.

Moving the published port sidesteps it **without depending on any theory about macOS bind semantics** — nothing kubefwd forwards lands on 55432.

Worth recording, since it's the reason this PR isn't a one-line `127.0.0.1:` prefix: an earlier attempt to reason about wildcard-vs-specific binding *did not survive testing*. With a specific loopback alias holding 5432, Docker bound both `0.0.0.0:5432` and `127.0.0.1:5432` anyway. The precise collision mechanism is still uncharacterized, so this picks immunity over cleverness.

**Only the published host port moves.** Container-to-container traffic still uses 5432, so `LIQUIBASE_COMMAND_URL` in the same file, `docker-compose.unraid.yml`, and `application-unraid.yml` are all deliberately untouched. CI needs no change — `api-type-drift` uses `docker-compose.local.yml` and `application-local.yml`, which move together.

### Rejected: a shared dev database on the Unraid box

It was the original ask, and it costs more than it solves:

- Per-query latency on a round-trip-chatty stack (Liquibase, Hibernate) — every boot and every type-drift run
- It stops being disposable; a reset there strips the init script's `GRANT`s, so cleanup is manual rather than free
- Offline development ends
- It would sit beside the pilot's **production** data behind a similar connection string — the exact confusion the separate-migrate-container design exists to prevent
- CI still needs a local Postgres regardless, so it'd be two paths to maintain

None of that buys anything a port number doesn't.

## Test plan

- [x] `docker compose -f docker-compose.local.yml up -d --wait postgres` → healthy, `port postgres 5432` reports `0.0.0.0:55432`
- [x] `run --rm migrate` applies cleanly — 6 changesets, "update has been successful"
- [x] `tco_app` connects from the host on 55432: `search_path=tco, public`, 4 tables in `tco`
- [x] `tco_migrate` reads `public.databasechangelog` — 6 rows
- [x] Host 5432 left free for kubefwd
- [x] `./gradlew :server:build ktlintCheck detekt` clean
- [ ] CI green (`api-type-drift` is the real check — it boots this compose file and connects via `application-local.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)