### PR TITLE
Dashboard landing page + client-side routing

### DIFF
--- a/.claude/skills/frontend-feature/SKILL.md
+++ b/.claude/skills/frontend-feature/SKILL.md
@@ -9,12 +9,15 @@ Stack rationale (why Mantine, why no global store) is in `docs/architecture.md` 
 This is how to write code that fits.
 
 **Actually installed**: React 19, TypeScript 5.7, Vite 6, ESLint 9 flat config, Mantine 9
-(`@mantine/core` + `@mantine/hooks`), TanStack Query v5, `openapi-typescript`.
+(`@mantine/core` + `@mantine/hooks`), TanStack Query v5, `openapi-typescript`, **react-router 7**
+(Data Router — import from `react-router`, not `react-router-dom`).
 
 **Pinned but not yet installed** — install per-feature when the first real need lands, not
-preemptively: React Router v6.4+ (Data Router), react-hook-form + Zod
-(`@hookform/resolvers/zod`), Vitest + React Testing Library + user-event + MSW. Update
-`package.json` when you add one.
+preemptively: react-hook-form + Zod (`@hookform/resolvers/zod`), Vitest + React Testing Library
++ user-event + MSW. Update `package.json` when you add one.
+
+**Why 7 and not 8**: react-router 8 requires React `>=19.2.7` and the project is on 19.2.6.
+Bump React first if you want 8; don't do it inside an unrelated feature PR.
 
 ## API modules — the core contract
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,8 @@
         "@mantine/hooks": "^9.2.1",
         "@tanstack/react-query": "^5.100.13",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router": "^7.18.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",
@@ -2223,6 +2224,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3423,6 +3437,28 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -3532,6 +3568,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "@mantine/hooks": "^9.2.1",
     "@tanstack/react-query": "^5.100.13",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router": "^7.18.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,39 +1,7 @@
-import { Badge, Center, Container, Group, Loader, Stack, Title } from '@mantine/core'
+import { RouterProvider } from 'react-router'
 
-import { useMe } from '@/api/auth'
-import ApiErrorAlert from '@/components/ApiErrorAlert'
-import OAuthErrorAlert from '@/components/OAuthErrorAlert'
-import PingCard from '@/components/PingCard'
-import SignInCard from '@/components/SignInCard'
-import UserBadge from '@/components/UserBadge'
-import { useOAuthTokenBridge } from '@/hooks/useOAuthTokenBridge'
+import { router } from '@/router/routes'
 
 export default function App() {
-  const oauthError = useOAuthTokenBridge()
-  const me = useMe()
-
-  return (
-    <Container size="sm" py="xl">
-      <Stack gap="lg">
-        <Group justify="space-between" align="baseline">
-          <Title order={1}>tc-overwatch</Title>
-          {me.data ? <UserBadge me={me.data} /> : <Badge color="blue" variant="light">scaffold</Badge>}
-        </Group>
-
-        <OAuthErrorAlert error={oauthError} />
-
-        {me.isPending && (
-          <Center>
-            <Loader />
-          </Center>
-        )}
-
-        {me.isError && <ApiErrorAlert error={me.error} title="Couldn't load session" />}
-
-        {!me.isPending && !me.data && <SignInCard />}
-
-        {me.data && <PingCard />}
-      </Stack>
-    </Container>
-  )
+  return <RouterProvider router={router} />
 }

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,22 @@
+import { Stack, Text } from '@mantine/core'
+import type { ReactNode } from 'react'
+
+type EmptyStateProps = {
+  title: string
+  description?: string
+  children?: ReactNode
+}
+
+export default function EmptyState({ title, description, children }: EmptyStateProps) {
+  return (
+    <Stack gap="xs" align="center" py="lg">
+      <Text fw={600}>{title}</Text>
+      {description && (
+        <Text size="sm" c="dimmed" ta="center" maw="42ch">
+          {description}
+        </Text>
+      )}
+      {children}
+    </Stack>
+  )
+}

--- a/frontend/src/components/RootLayout.tsx
+++ b/frontend/src/components/RootLayout.tsx
@@ -1,0 +1,41 @@
+import { Badge, Center, Container, Group, Loader, Stack, Title } from '@mantine/core'
+import { Outlet } from 'react-router'
+
+import { useMe } from '@/api/auth'
+import ApiErrorAlert from '@/components/ApiErrorAlert'
+import OAuthErrorAlert from '@/components/OAuthErrorAlert'
+import SignInCard from '@/components/SignInCard'
+import UserBadge from '@/components/UserBadge'
+import { useOAuthTokenBridge } from '@/hooks/useOAuthTokenBridge'
+
+export default function RootLayout() {
+  const oauthError = useOAuthTokenBridge()
+  const me = useMe()
+
+  return (
+    <Container size="md" py="xl">
+      <Stack gap="lg">
+        <Group justify="space-between" align="baseline">
+          <Title order={1}>tc-overwatch</Title>
+          {me.data ? <UserBadge me={me.data} /> : <Badge color="blue" variant="light">scaffold</Badge>}
+        </Group>
+
+        <OAuthErrorAlert error={oauthError} />
+
+        {me.isPending && (
+          <Center>
+            <Loader />
+          </Center>
+        )}
+
+        {me.isError && <ApiErrorAlert error={me.error} title="Couldn't load session" />}
+
+        {/* The gate is here rather than in a route guard: with two routes, a
+            redirect loop costs more than it buys. Revisit at the third route. */}
+        {!me.isPending && !me.data && <SignInCard />}
+
+        {me.data && <Outlet />}
+      </Stack>
+    </Container>
+  )
+}

--- a/frontend/src/components/dashboard/ActiveTransactionsSection.tsx
+++ b/frontend/src/components/dashboard/ActiveTransactionsSection.tsx
@@ -1,0 +1,13 @@
+import DashboardSection from '@/components/dashboard/DashboardSection'
+import EmptyState from '@/components/EmptyState'
+
+export default function ActiveTransactionsSection() {
+  return (
+    <DashboardSection title="Active transactions" hint="Sorted by what needs you first">
+      <EmptyState
+        title="No transactions yet"
+        description="Each property address becomes a transaction once tc-overwatch recognises it in your mail."
+      />
+    </DashboardSection>
+  )
+}

--- a/frontend/src/components/dashboard/DashboardSection.tsx
+++ b/frontend/src/components/dashboard/DashboardSection.tsx
@@ -1,0 +1,26 @@
+import { Card, Group, Text, Title } from '@mantine/core'
+import type { ReactNode } from 'react'
+
+type DashboardSectionProps = {
+  title: string
+  hint?: string
+  children: ReactNode
+}
+
+export default function DashboardSection({ title, hint, children }: DashboardSectionProps) {
+  return (
+    <Card withBorder radius="md" p="lg" component="section">
+      <Group justify="space-between" align="baseline" mb="sm">
+        <Title order={3} size="h5" tt="uppercase">
+          {title}
+        </Title>
+        {hint && (
+          <Text size="xs" c="dimmed">
+            {hint}
+          </Text>
+        )}
+      </Group>
+      {children}
+    </Card>
+  )
+}

--- a/frontend/src/components/dashboard/NeedsAttentionSection.tsx
+++ b/frontend/src/components/dashboard/NeedsAttentionSection.tsx
@@ -1,0 +1,23 @@
+import { SimpleGrid } from '@mantine/core'
+
+import DashboardSection from '@/components/dashboard/DashboardSection'
+import EmptyState from '@/components/EmptyState'
+
+// Two adjacent feeds per #44. Referral warnings earn top billing on risk, not
+// volume — there will be few, and each one can cost a commission.
+export default function NeedsAttentionSection() {
+  return (
+    <DashboardSection title="Needs you now">
+      <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="lg">
+        <EmptyState
+          title="No new business"
+          description="Inbound enquiries that look like new deals show up here as email is triaged."
+        />
+        <EmptyState
+          title="No referral warnings"
+          description="Email suggesting a client is working with another agent shows up here."
+        />
+      </SimpleGrid>
+    </DashboardSection>
+  )
+}

--- a/frontend/src/components/dashboard/ReviewQueuesSection.tsx
+++ b/frontend/src/components/dashboard/ReviewQueuesSection.tsx
@@ -1,0 +1,44 @@
+import { Accordion } from '@mantine/core'
+
+import DashboardSection from '@/components/dashboard/DashboardSection'
+import EmptyState from '@/components/EmptyState'
+
+// Collapsed by design: #45 calls these audit surfaces the TC pulls when she
+// wants them, not work pushed at her. Her problem is too much to look at.
+const QUEUES = [
+  {
+    value: 'unmatched',
+    label: 'Unmatched email',
+    empty: 'Nothing unmatched',
+    description: 'Transaction-shaped email where no property address could be identified.',
+  },
+  {
+    value: 'auto-promoted',
+    label: 'Auto-promoted contacts',
+    empty: 'Nothing to review',
+    description: 'People added to your known-contacts directory automatically, listed here so you can audit them.',
+  },
+  {
+    value: 'collisions',
+    label: 'Label collisions',
+    empty: 'No collisions',
+    description: 'Two transactions sharing an address. The applied suffix is shown here so you can override it.',
+  },
+]
+
+export default function ReviewQueuesSection() {
+  return (
+    <DashboardSection title="Review when you have time">
+      <Accordion variant="separated" radius="md">
+        {QUEUES.map((queue) => (
+          <Accordion.Item key={queue.value} value={queue.value}>
+            <Accordion.Control>{queue.label}</Accordion.Control>
+            <Accordion.Panel>
+              <EmptyState title={queue.empty} description={queue.description} />
+            </Accordion.Panel>
+          </Accordion.Item>
+        ))}
+      </Accordion>
+    </DashboardSection>
+  )
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,19 @@
+import { Stack } from '@mantine/core'
+
+import ActiveTransactionsSection from '@/components/dashboard/ActiveTransactionsSection'
+import NeedsAttentionSection from '@/components/dashboard/NeedsAttentionSection'
+import ReviewQueuesSection from '@/components/dashboard/ReviewQueuesSection'
+import UnderConstructionBanner from '@/components/UnderConstructionBanner'
+
+// Order is the priority contract, not a layout preference: push (money and
+// risk) → the working surface → pull (audit surfaces). See docs/task-inventory.md §9.
+export default function DashboardPage() {
+  return (
+    <Stack gap="lg">
+      <UnderConstructionBanner />
+      <NeedsAttentionSection />
+      <ActiveTransactionsSection />
+      <ReviewQueuesSection />
+    </Stack>
+  )
+}

--- a/frontend/src/pages/ScaffoldPage.tsx
+++ b/frontend/src/pages/ScaffoldPage.tsx
@@ -1,0 +1,8 @@
+import PingCard from '@/components/PingCard'
+
+// feature/ping is the scaffold's end-to-end smoke test, not product surface.
+// It lives on its own route so it stays reachable without sitting on the
+// dashboard the TC actually uses.
+export default function ScaffoldPage() {
+  return <PingCard />
+}

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -1,0 +1,16 @@
+import { createBrowserRouter } from 'react-router'
+
+import RootLayout from '@/components/RootLayout'
+import DashboardPage from '@/pages/DashboardPage'
+import ScaffoldPage from '@/pages/ScaffoldPage'
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <RootLayout />,
+    children: [
+      { index: true, element: <DashboardPage /> },
+      { path: 'scaffold', element: <ScaffoldPage /> },
+    ],
+  },
+])


### PR DESCRIPTION
## Summary

Signing in landed the TC on the scaffold's ping card. This makes the dashboard the landing page and starts epic #19 — with the *layout*, not the data, because there is no transaction, contact, or triage backend to read from yet.

**The section order is the priority contract from `docs/task-inventory.md` §9, not a visual preference:**

1. **Needs you now** — new business + referral warnings, two adjacent feeds (#44)
2. **Active transactions** — the working surface (#43)
3. **Review when you have time** — collapsed accordion: unmatched email, auto-promoted contacts, label collisions (#46, #45, #47)

§9 marks metrics widgets `[BACKLOG]` and everything else `[FOCUS]` — that's the spec choosing a **work queue over a BI dashboard**, and this follows it. A grid of per-feature tiles would organise around our code rather than her priorities, and would make every item look equally urgent. Referral warnings sit at the top not on volume (there'll be one a month) but because that one can cost a commission. The review lists are collapsed because #45 calls them audit surfaces the TC *pulls* when she wants them — her problem is already too much to look at.

### Empty states, not placeholder rows

Every section renders its real empty state. Fabricated transactions on a pilot user's dashboard are believable, which is exactly the problem, and hand-written row types would fight the generated-types rule `api-type-drift` enforces.

**These aren't scaffolding to delete later.** A new TC sees precisely this on day one, before any backfill completes — so it's shipping UI, and building it first forces us to design the first-run experience rather than discover it.

### Deviations worth recording

- **react-router 7, not 8.** 8 requires React `>=19.2.7`; we're on 19.2.6. Bumping React inside a dashboard PR turns a small review into a debugging session. The `frontend-feature` skill now records this with the upgrade path, and moves React Router from "pinned but not installed" to installed.
- **`PingCard` moved to `/scaffold`.** It's the scaffold's smoke test, not product surface — but deleting it removes the only proof the API round-trips, so it keeps its own route.
- **No clickable logo → home link.** Mantine 9's polymorphic typing won't forward `to`, and with two routes and no nav there is currently nothing to navigate back *from*. Not worth a typing workaround for a dead link; it returns with transaction details.
- **The under-construction banner now also sits atop the dashboard**, where it earns its keep — it explains why everything below is empty.

### Follow-ups not done here

- **`useOAuthTokenBridge` calls `window.history.replaceState` directly** to strip the token fragment. React Router doesn't observe that, so its `location` keeps the stale value. Harmless today — nothing reads `useSearchParams` — but the first person to add URL state gets a confusing stale read. Deserves its own issue rather than a speculative fix here.
- **Bundle grew 308 KB → 416 KB raw (94 → 130 KB gzipped)**, all react-router. Real cost for two routes; it amortises as routes multiply, and the alternative was deferring routing until transaction details needs it.
- The auth gate lives in `RootLayout` rather than a route guard. With two routes, a redirect loop costs more than it buys — noted in the code to revisit at the third route.

No backend change, so `api-type-drift` is untouched.

## Test plan

- [x] `npm --prefix frontend run build` clean (tsc + vite)
- [x] `npm --prefix frontend run lint` clean
- [x] Signed in against a local backend: dashboard renders at `/` with all three sections and their empty states; `/scaffold` serves the ping card
- [x] `nginx.conf` already has `try_files $uri /index.html`, so `/scaffold` survives a refresh in production
- [ ] CI green
- [ ] After merge: `https://app.tc-overwatch.net` lands on the dashboard after Google sign-in

Starts #19. Does not close #43–#48 — each of those lands when its data exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)